### PR TITLE
feat(#164 WI-3): VLog + ring buffer + composite source; 6 Log sites migrated behind a real gate

### DIFF
--- a/.claude/codex-audits/feat-164-wi-3-vlog-ring-audit.md
+++ b/.claude/codex-audits/feat-164-wi-3-vlog-ring-audit.md
@@ -1,0 +1,137 @@
+---
+branch: feat/164-wi-3-vlog-ring
+threadId: 019fcf1e-ee13-7a13-ac87-67573bb65122
+rounds: 3
+final_verdict: block-recommended
+date: 2026-08-05
+---
+
+# Gate-4 audit — feature #164 WI-3 (VLog + ring buffer + composite source)
+
+Auditor: Codex `gpt-5.6-sol` via `scripts/run-codex.sh` (rule 53), read-only sandbox.
+Round transcripts: `.reports/audit-r1.txt`, `.reports/audit-r2.txt`, `.reports/audit-r3.txt`.
+
+| Round | threadId | Findings | Verdict |
+| --- | --- | --- | --- |
+| 1 | `019fcf08-bc6d-7d40-8be2-60b930989c12` | C0 **H1** M2 L1 | block-recommended |
+| 2 | `019fcf12-a720-7f20-b935-1ca94fe19606` | C0 **H1** M3 L1 | block-recommended |
+| 3 | `019fcf1e-ee13-7a13-ac87-67573bb65122` | C0 **H1** M2 L1 | block-recommended |
+
+**Status: escalated at the 3-round cap (rule 47 Gate 4).** Every round's findings were
+addressed — fixed, or explicitly accepted with rationale below — and all gates are green, but
+round 3's fixes have had no independent review and the standing verdict is `block-recommended`.
+The orchestrator decides: accept the two documented residuals, or requeue for a 4th round.
+
+## Round 1
+
+**HIGH — sequence ids collided across process launches.** `VLog`'s counter restarted at 1 every
+launch while logd deliberately retains prior-launch entries, so the current process's first ids
+were the previous launch's first ids. `CompositeDiagnosticsSource` prefers the ring on an id
+collision, so it dropped exactly the pre-crash breadcrumbs the platform log exists to provide —
+on *every* launch. FIXED: the id is now `nonce | counter` (21 random per-launch bits + a 42-bit
+counter), still a positive `Long` that WI-1's `«v(\d+)»` marker regex parses unchanged.
+Regression tests `idsFromTwoLaunchesWithDistinctNoncesDoNotCollide` and
+`aPriorLaunchLogcatEntryIsNotDroppedByTheCurrentLaunchsRing`; both verified RED against a bare
+counter.
+
+**MEDIUM — the containment gate had four one-line evasions.** It keyed on call *shapes*, so
+`import android.util.Log as PlatformLog`, `import android.util.*`, a qualified call split across
+lines, and `Class.forName("android.util.Log")` all passed; `.java` sources and non-`main` source
+sets were never scanned. FIXED: the gate bans the *name* rather than the shapes, and scans `.kt`
++ `.java` across source sets. Fixtures added for each evasion.
+
+**MEDIUM — the ring concurrency test did not establish an overlapping read.** FIXED (twice — see
+round 2).
+
+**LOW — `VLogTest.kt` exceeds ~300 lines and hosts a second test class.** ACCEPTED: WI-3's
+write-set allots exactly three test files while owning `DiagnosticsCategoryBounding.kt`, whose
+acceptance bullet sits in WI-4 (which cannot write this file). The alternative was shipping the
+source untested. Splitting it out is a one-line follow-up for whoever holds a wider write-set.
+
+## Round 2
+
+**HIGH — `install()` published the nonce and the counter reset as two independent writes.** An
+`emit` could read the old nonce, be descheduled across `install()`, then increment the
+freshly-reset counter into `oldNonce|1` — a duplicate of an id the old generation had already
+issued. FIXED: nonce and counter became one immutable object swapped atomically; round 3 widened
+that to include `sink` and `clock` (see below).
+
+**MEDIUM — the gate's comment stripping was not syntax-aware.** `/** doc */ val p =
+android.util.Log.WARN` was skipped whole (line began with a block comment) and
+`"https://x".length + android.util.Log.WARN` was cut at a `//` inside a string literal. FIXED
+with an awk state machine tracking multi-line block comments, inline spans, and `//` only outside
+a string.
+
+**MEDIUM — the gate scanned only `android/app/src`.** FIXED: the whole `android/` tree, so
+`:identity` and any future module are covered; `build/` output pruned; non-shipped source sets
+matched as the segment directly beneath a module rather than as a loose substring.
+
+**MEDIUM — the concurrency test proved only that a read saw an incomplete buffer.** FIXED: it now
+counts *distinct* intermediate snapshot sizes and requires 10, which only interleaved reads
+produce. The first attempt at that assertion FAILED honestly — a cold reader's first `runBlocking`
+snapshot costs more than the whole write burst, so it always sampled after the writers finished;
+the reader now warms up on the empty ring and releases the writers only once it is looping hot.
+
+**LOW — a blank category vanished from the chip row.** `chipFor` returned `null`, contradicting
+the documented rule that everything uncategorised collapses into one *filterable* bucket, and
+`LogcatLineParser` legitimately yields `""` for a tagless line. FIXED: blank buckets like any
+other unknown tag.
+
+## Round 3
+
+**HIGH — duplicate ids remain representable across concurrent `install()` calls.** Two parts.
+The part that is a real defect — `sink`, `clock` and the generation were three independent writes,
+so a concurrent emit could pair a new counter with the old sink — is FIXED: all four are now one
+immutable `Installation` published through a single `AtomicReference`, and `emit` takes one
+snapshot of it. The other part (two installs sharing a nonce yield the same ids) is the
+probabilistic residual accepted below.
+
+**MEDIUM — the lexer was not Kotlin-raw-string aware.** `val x = """ " // raw text """` left the
+machine mid-string, so the `//` on the next construct read as a comment and hid a reference.
+FIXED: a persistent `"""` raw-string state plus char-literal handling; fixtures `RawString.kt` and
+`CharLiteral.kt`.
+
+**MEDIUM — the concurrency test remains scheduler-dependent.** PARTLY FIXED, PARTLY ACCEPTED. The
+strand path is closed (`start.await()` moved inside `try`/`finally` for both reader and writers).
+The proposed remedy — phased writer/reader milestones — is what the *previous* revision did and
+what this same auditor rejected in round 2 as proving less, so re-adopting it would just
+oscillate. The design is validated empirically instead: with `synchronized` removed the test fails
+**4 runs out of 4**; with it restored it passes **5 runs out of 5**. The residual failure mode is a
+loud assertion failure, never a vacuous pass. The suggested performance concern is refuted by
+measurement: the test runs in **33 ms**.
+
+**LOW — trailing slash on the scan root broke the relative-path strip.** FIXED (`${1%/}`), with a
+self-test asserting an identical finding set either way.
+
+## Explicitly accepted residuals
+
+1. **Nonce repeat, ~1 in 2^21 per launch pair.** Eliminating it needs durable state — a counter or
+   epoch persisted to disk and read at start-up — which puts an I/O dependency and a failure mode
+   inside a logging facade. The loss on a repeat is bounded: a handful of prior-launch logcat
+   entries whose counters overlap the current ring's are deduped away. Strictly better than the
+   pre-fix behavior, where that happened every launch. Recorded in `VLog.kt`'s KDoc.
+2. **A runtime-assembled class name** (`Class.forName("android." + "util.Log")`) is invisible to
+   any textual gate. The gate stops accidental drift and honest reintroduction; it is not an
+   adversarial sandbox. Catching this needs bytecode or dependency analysis — out of scope for
+   WI-3. Recorded in the script header.
+3. **`VLogTest.kt` size / second test class** — write-set constraint, see round 1.
+
+## Verification
+
+- `RUN-ANDROID-TESTS RESULT: SUCCEEDED` — 213 tests, 0 failures, 0 errors (JUnit XML, not the
+  `BUILD SUCCESSFUL` line): the three new WI-3 suites plus WI-1/WI-2's, plus the JVM suites of
+  every migrated file (`BookShareIntentTest`, `SearchIndexCoordinatorTest`,
+  `FoliateBridgePolicyTest`).
+- `scripts/__tests__/check-android-log-containment.sh` → `ALL PASS` (23 self-test assertions incl.
+  9 evasion fixtures and 3 false-positive fixtures; the real `android/` tree scans clean).
+
+### Mutation testing (every claim below was run, not reasoned)
+
+| Mutation | Expected | Observed |
+| --- | --- | --- |
+| Remove the `android.util.Log` forward from `VLog.emit` | forwarding tests red, ring tests green | 8 forwarding tests RED; all 15 ring tests and every ring-side `VLogTest` case GREEN |
+| Dedupe on `(time, category, message)` instead of the sequence id | look-alike-survival tests red | 3 RED incl. `twoDistinctEntriesWithByteIdenticalTextAndTimestampBothSurvive` |
+| Disable dedupe entirely | "appears exactly once" red | 3 RED incl. `anEventPresentInBothSourcesAppearsExactlyOnce` |
+| Drop the launch nonce (bare counter) | cross-launch tests red | 2 RED: `idsFromTwoLaunchesWithDistinctNoncesDoNotCollide`, `aPriorLaunchLogcatEntryIsNotDroppedByTheCurrentLaunchsRing` |
+| Remove `synchronized` from the ring | concurrency test red | RED 4/4 runs (`ArrayIndexOutOfBoundsException` from a concurrently-growing `ArrayDeque`) |
+| Reintroduce a short-form `Log.w(` into `PdfDocument.kt` | containment gate fails | `PdfDocument.kt:103` reported, `FAIL — production sources still reference android.util.Log` |

--- a/.claude/codex-audits/feat-164-wi-3-vlog-ring-audit.md
+++ b/.claude/codex-audits/feat-164-wi-3-vlog-ring-audit.md
@@ -1,8 +1,8 @@
 ---
 branch: feat/164-wi-3-vlog-ring
 threadId: 019fcf1e-ee13-7a13-ac87-67573bb65122
-rounds: 3
-final_verdict: block-recommended
+rounds: 4
+final_verdict: follow-up-recommended
 date: 2026-08-05
 ---
 
@@ -102,6 +102,36 @@ measurement: the test runs in **33 ms**.
 
 **LOW — trailing slash on the scan root broke the relative-path strip.** FIXED (`${1%/}`), with a
 self-test asserting an identical finding set either way.
+
+## Round 4 — confirming round (orchestrator-run, 2026-08-05)
+
+The lane correctly escalated rather than certifying its own round-3 fixes (rule 48). Those were
+**real concurrency and lexer code**, not documentation, so this was confirmed by audit rather than
+accepted by argument — the same standard applied to WI-1, where a confirming round found a third
+`CancellationException` site the lane had missed.
+
+Run by the **orchestrator** via `scripts/run-codex.sh` (Codex gpt-5.5/high, read-only), scoped to
+the round-3 fixes in `7f3afd2b` plus a rounds-1–2 regression check.
+
+**`VERDICT: clean` — zero findings at any severity.**
+
+- **The atomic `Installation` fix is complete.** The snapshot is taken once and used consistently
+  throughout `emit`; no remaining read of installation state escapes it, on any path including the
+  uninstalled one. Racing `install()` calls are **whole-object last-writer-wins, not torn.**
+- **The raw-string lexer fix holds** across nested quotes, `//` and `/*` inside a raw string, the
+  literal text `Log.w(` inside a raw string, an unterminated raw string at EOF, a char literal
+  `'"'`, and an escaped quote in a normal string — detecting a genuine reference elsewhere in the
+  same file in each case, without false-positiving on the literal text.
+- **No regression** in rounds 1–2: `emit` still forwards unconditionally including before
+  `install()`, sequence-id monotonicity holds under concurrency, and the gate reports the correct
+  relative path after the `${1%/}` fix.
+
+One caveat the auditor stated itself: it could not execute the full self-test fixture because its
+sandbox is read-only, but read-only `--scan android` and `--scan android/` both returned clean. The
+lane's own run of the suite (23 assertions, `ALL PASS`) and the orchestrator's re-run cover that.
+
+**`final_verdict` is therefore `follow-up-recommended`** — zero open Critical/High/Medium, with the
+three residuals below carried as accepted and recorded in the code rather than closed.
 
 ## Explicitly accepted residuals
 

--- a/android/app/src/main/kotlin/com/vreader/app/diagnostics/CompositeDiagnosticsSource.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/diagnostics/CompositeDiagnosticsSource.kt
@@ -1,0 +1,91 @@
+package com.vreader.app.diagnostics
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Purpose: Feature #164 WI-3 — one source over two: the platform log ([primary], normally
+ * `LogcatDiagnosticsSource`) and the in-process floor ([secondary], the ring buffer).
+ *
+ * Key decisions:
+ * - **MERGE, never choose.** Whenever the primary is `Available` — including
+ *   `Available(emptyList())` — the ring's entries are merged in. The rejected v1 design inferred
+ *   availability from emptiness and served "primary else floor", which failed twice over: a
+ *   legitimately empty logcat flip-flopped the source on every load, and a *partially* populated
+ *   logcat hid the ring's entries entirely.
+ * - **Dedupe on IDENTITY, never on text.** The key is [DiagnosticsLogEntry.sequenceId], the id
+ *   VLog stamps on both representations of one event. A `(time, level, tag, message)` key would
+ *   collapse two genuinely distinct events that share byte-identical text and timestamp — a
+ *   realistic shape for a repeated handled condition — and logd's timestamp rewriting and
+ *   4068-byte truncation make the "same" event differ between the sources anyway.
+ * - **Fail OPEN on retention.** An entry whose `sequenceId` is null (framework/library line, or a
+ *   marker lost to truncation) is always kept: dedupe never drops what it cannot positively
+ *   identify. A duplicate visible entry is a cosmetic annoyance; a silently dropped one is a lost
+ *   bug report.
+ * - **The RING copy wins a collision.** Both carry the same text in the normal case, but logd
+ *   truncates the tail — so preferring the ring's copy is what keeps the end of a long stack trace.
+ * - **No exception escapes** except [CancellationException]: a source failure is data
+ *   (`Unavailable`), but cancelling the caller is not a source failure and must not be swallowed.
+ *
+ * @coordinates-with LogcatDiagnosticsSource.kt, RingBufferDiagnosticsSource.kt, VLog.kt
+ */
+class CompositeDiagnosticsSource(
+    private val primary: DiagnosticsLogSource,
+    private val secondary: DiagnosticsLogSource,
+) : DiagnosticsLogSource {
+
+    override suspend fun recentEntries(sinceMillis: Long?, limit: Int): SourceResult {
+        val primaryResult = read(primary, sinceMillis, limit, "primary")
+        val secondaryResult = read(secondary, sinceMillis, limit, "secondary")
+
+        val primaryEntries = (primaryResult as? SourceResult.Available)?.entries
+        val secondaryEntries = (secondaryResult as? SourceResult.Available)?.entries
+
+        if (primaryEntries == null && secondaryEntries == null) {
+            return SourceResult.Unavailable(
+                "${(primaryResult as SourceResult.Unavailable).reason}; " +
+                    (secondaryResult as SourceResult.Unavailable).reason,
+            )
+        }
+        if (limit <= 0) return SourceResult.Available(emptyList())
+
+        val merged = mergeDeduped(
+            preferred = secondaryEntries.orEmpty(),
+            other = primaryEntries.orEmpty(),
+        )
+        return SourceResult.Available(merged.takeLast(limit.coerceAtMost(merged.size)))
+    }
+
+    /**
+     * [preferred] is emitted first so that a stable sort keeps its copy ahead of an equal-timestamp
+     * twin, and so that its copy is the one that claims a colliding sequence id.
+     */
+    private fun mergeDeduped(
+        preferred: List<DiagnosticsLogEntry>,
+        other: List<DiagnosticsLogEntry>,
+    ): List<DiagnosticsLogEntry> {
+        val claimed = HashSet<Long>(preferred.size + other.size)
+        val kept = ArrayList<DiagnosticsLogEntry>(preferred.size + other.size)
+        for (entry in preferred) {
+            val id = entry.sequenceId
+            if (id == null || claimed.add(id)) kept += entry
+        }
+        for (entry in other) {
+            val id = entry.sequenceId
+            if (id == null || claimed.add(id)) kept += entry
+        }
+        return kept.sortedBy { it.timeMillis }
+    }
+
+    private suspend fun read(
+        source: DiagnosticsLogSource,
+        sinceMillis: Long?,
+        limit: Int,
+        label: String,
+    ): SourceResult = try {
+        source.recentEntries(sinceMillis, limit)
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (t: Throwable) {
+        SourceResult.Unavailable("$label threw ${t.javaClass.simpleName}: ${t.message}")
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/diagnostics/DiagnosticsCategory.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/diagnostics/DiagnosticsCategory.kt
@@ -1,0 +1,29 @@
+package com.vreader.app.diagnostics
+
+/**
+ * Purpose: Feature #164 WI-3 — the subsystem vocabulary vreader's own log entries carry.
+ *
+ * The set is NOT ours to choose: it is the design's category chip row verbatim
+ * (`DIAG_CATEGORIES` in `dev-docs/designs/vreader-fidelity-v1/project/vreader-diagnostics.jsx`,
+ * minus the constant leading `All` chip). Inventing a category here would put a chip on a
+ * designed surface that the design does not depict (rule 51).
+ *
+ * Why an enum at all, rather than reusing logcat tags: logcat tags are arbitrary per-file strings
+ * (`"ReaderActivity"`, `"FoliateBridge"`, `"BookShare"`, `"SearchIndexCoordinator"`), so four of
+ * this app's six log sites would have landed in four unrelated chips. `VLog` + this enum is what
+ * gives our entries a stable vocabulary; the original class name is not lost — it moves into the
+ * message body as a `[ClassName]` prefix.
+ *
+ * Android-only concerns map ONTO this set rather than extending it:
+ * search indexing -> [LIBRARY], Room/DAO -> [PERSISTENCE], share/export -> [LIBRARY].
+ *
+ * @coordinates-with VLog.kt, DiagnosticsCategoryBounding.kt
+ */
+enum class DiagnosticsCategory(val tag: String) {
+    LIBRARY("Library"),
+    PERSISTENCE("Persistence"),
+    READER("Reader"),
+    AI("AI"),
+    SYNC("Sync"),
+    DEBUG_BRIDGE("DebugBridge"),
+}

--- a/android/app/src/main/kotlin/com/vreader/app/diagnostics/DiagnosticsCategoryBounding.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/diagnostics/DiagnosticsCategoryBounding.kt
@@ -66,10 +66,17 @@ object DiagnosticsCategoryBounding {
         "readium" to DiagnosticsCategory.READER,
     )
 
-    /** The chip an entry with this raw [category] is filed under. Never returns `All`. */
-    fun chipFor(category: String): String? {
+    /**
+     * The chip an entry with this raw [category] is filed under. Never returns [ALL].
+     *
+     * A BLANK category is bucketed, not dropped (Gate-4 round-2 Low): `LogcatLineParser` yields
+     * `""` for an otherwise valid line whose tag column is absent, and dropping it would make those
+     * entries reachable only under `All` — contradicting rule 3 and this object's own promise that
+     * filtering still reaches every collapsed entry.
+     */
+    fun chipFor(category: String): String {
         val trimmed = category.trim()
-        if (trimmed.isEmpty()) return null
+        if (trimmed.isEmpty()) return COLLAPSED_BUCKET
         val key = trimmed.lowercase()
         DESIGNED[key]?.let { return it }
         KNOWN_TAGS[key]?.let { return it.tag }
@@ -85,7 +92,7 @@ object DiagnosticsCategoryBounding {
     fun chips(entries: List<DiagnosticsLogEntry>): List<String> {
         val counts = LinkedHashMap<String, Int>()
         for (entry in entries) {
-            val chip = chipFor(entry.category) ?: continue
+            val chip = chipFor(entry.category)
             counts[chip] = (counts[chip] ?: 0) + 1
         }
         val ranked = counts.entries

--- a/android/app/src/main/kotlin/com/vreader/app/diagnostics/DiagnosticsCategoryBounding.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/diagnostics/DiagnosticsCategoryBounding.kt
@@ -1,0 +1,102 @@
+package com.vreader.app.diagnostics
+
+/**
+ * Purpose: Feature #164 WI-3 — keeps the designed category chip row BOUNDED.
+ *
+ * The merged feed carries raw logcat tags from the framework and every library (Readium,
+ * chromium, `SQLiteLog`, ART, `ziparchive`, …). The design shows a scrollable row of seven chips;
+ * production tags left unbounded would render dozens. The rule, in order:
+ *
+ * 1. a tag that already IS a [DiagnosticsCategory.tag] keeps it (our own entries);
+ * 2. a known third-party tag maps onto the nearest designed category via the explicit table below
+ *    — explicit, because guessing from substrings mislabels more than it helps;
+ * 3. everything else collapses into ONE bucket;
+ * 4. the chip row is hard-capped, ranked by entry count.
+ *
+ * **Filtering still reaches a collapsed entry** — only the CHIP SET is capped, never the data.
+ * [chipFor] is the mapping the filter uses, so "show me the bucket" shows every entry that
+ * collapsed into it.
+ *
+ * Rule-51 note for whoever builds the chip row (WI-6a): [COLLAPSED_BUCKET]'s LABEL is not in the
+ * design bundle (`DIAG_CATEGORIES` is `All` + the six [DiagnosticsCategory] tags). It is a single
+ * named constant precisely so that adjudication happens in one place rather than being scattered
+ * through the UI.
+ *
+ * @coordinates-with DiagnosticsCategory.kt, DiagnosticsLogEntry.kt
+ */
+object DiagnosticsCategoryBounding {
+
+    /** The design's constant leading chip (`DIAG_CATEGORIES[0]`); never derived from the data. */
+    const val ALL: String = "All"
+
+    /** Rule 3's single bucket for every unrecognised raw tag. */
+    const val COLLAPSED_BUCKET: String = "Other"
+
+    /**
+     * Rule 4's cap: the six designed categories plus the bucket. `All` is additional — it is a
+     * filter constant, not a data-derived chip.
+     */
+    const val MAX_CATEGORY_CHIPS: Int = 7
+
+    private val DESIGNED: Map<String, String> =
+        DiagnosticsCategory.entries.associate { it.tag.lowercase() to it.tag }
+
+    /** Rule 2 — exact third-party tags, lowercased for comparison. */
+    private val KNOWN_TAGS: Map<String, DiagnosticsCategory> = mapOf(
+        // Room / SQLite
+        "sqlitelog" to DiagnosticsCategory.PERSISTENCE,
+        "sqlitedatabase" to DiagnosticsCategory.PERSISTENCE,
+        "sqliteconnectionpool" to DiagnosticsCategory.PERSISTENCE,
+        "room" to DiagnosticsCategory.PERSISTENCE,
+        // Rendering engines: Readium (EPUB), the WebView (AZW3/foliate), PdfRenderer (PDF)
+        "chromium" to DiagnosticsCategory.READER,
+        "webviewfactory" to DiagnosticsCategory.READER,
+        "readium" to DiagnosticsCategory.READER,
+        "epubnavigatorfragment" to DiagnosticsCategory.READER,
+        "pdfrenderer" to DiagnosticsCategory.READER,
+        // Network: WebDAV backup + OPDS
+        "okhttp" to DiagnosticsCategory.SYNC,
+        "networksecurityconfig" to DiagnosticsCategory.SYNC,
+        "trafficstats" to DiagnosticsCategory.SYNC,
+    )
+
+    /** Rule 2 — tag PREFIXES, for families that number their tags (chromium's `cr_*`). */
+    private val KNOWN_PREFIXES: List<Pair<String, DiagnosticsCategory>> = listOf(
+        "cr_" to DiagnosticsCategory.READER,
+        "readium" to DiagnosticsCategory.READER,
+    )
+
+    /** The chip an entry with this raw [category] is filed under. Never returns `All`. */
+    fun chipFor(category: String): String? {
+        val trimmed = category.trim()
+        if (trimmed.isEmpty()) return null
+        val key = trimmed.lowercase()
+        DESIGNED[key]?.let { return it }
+        KNOWN_TAGS[key]?.let { return it.tag }
+        KNOWN_PREFIXES.firstOrNull { key.startsWith(it.first) }?.let { return it.second.tag }
+        return COLLAPSED_BUCKET
+    }
+
+    /**
+     * The chip row for [entries]: `All` first, then at most [MAX_CATEGORY_CHIPS] chips ranked by
+     * entry count (descending), ties broken by the designed order so the row does not reshuffle
+     * between two loads that happen to tie.
+     */
+    fun chips(entries: List<DiagnosticsLogEntry>): List<String> {
+        val counts = LinkedHashMap<String, Int>()
+        for (entry in entries) {
+            val chip = chipFor(entry.category) ?: continue
+            counts[chip] = (counts[chip] ?: 0) + 1
+        }
+        val ranked = counts.entries
+            .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { designedRank(it.key) })
+            .take(MAX_CATEGORY_CHIPS)
+            .map { it.key }
+        return listOf(ALL) + ranked
+    }
+
+    /** Designed categories keep their design order; the bucket always sorts last. */
+    private fun designedRank(chip: String): Int =
+        DiagnosticsCategory.entries.indexOfFirst { it.tag == chip }.takeIf { it >= 0 }
+            ?: DiagnosticsCategory.entries.size
+}

--- a/android/app/src/main/kotlin/com/vreader/app/diagnostics/RingBufferDiagnosticsSource.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/diagnostics/RingBufferDiagnosticsSource.kt
@@ -1,0 +1,77 @@
+package com.vreader.app.diagnostics
+
+/**
+ * Purpose: Feature #164 WI-3 — the in-process capture floor and [VLog]'s sink.
+ *
+ * Two jobs, both load-bearing:
+ * - **Floor.** If the platform ever refuses an app its own logcat (an SELinux/OEM policy this
+ *   project cannot control — plan §2), this buffer is the entire feature. It therefore has no
+ *   dependency on any OS boundary and cannot report `Unavailable`.
+ * - **Fidelity.** logd truncates a payload at 4068 bytes; this buffer does not. When the composite
+ *   sees the same entry from both sources it keeps THIS copy.
+ *
+ * Key decisions:
+ * - **Bounded by construction.** `record` is called from arbitrary app threads for the process's
+ *   whole life, so an unbounded collection is a leak with a slow fuse. A non-positive capacity is
+ *   REJECTED rather than clamped: a zero-capacity ring would silently drop every entry, which is
+ *   the same class of silent degradation the explicit `SourceResult.Unavailable` signal exists to
+ *   prevent elsewhere.
+ * - **One monitor, snapshot-then-filter.** Readers copy under the lock and do all filtering
+ *   outside it, so a read can never observe a partially-applied eviction and a slow reader never
+ *   blocks a logging call for longer than the copy.
+ * - **`limit` selects the NEWEST entries but the result stays oldest -> newest** — the viewer
+ *   renders chronologically while wanting the tail of the log, and reversing at the boundary would
+ *   push that subtlety onto every caller.
+ *
+ * @coordinates-with VLog.kt, CompositeDiagnosticsSource.kt, DiagnosticsLogSource.kt
+ */
+class RingBufferDiagnosticsSource(private val capacity: Int = DEFAULT_CAPACITY) : DiagnosticsLogSource {
+
+    init {
+        require(capacity > 0) { "capacity must be > 0, was $capacity" }
+    }
+
+    private val lock = Any()
+
+    /** Guarded by [lock]. Head = oldest. */
+    private val entries = ArrayDeque<DiagnosticsLogEntry>()
+
+    /**
+     * Append one entry, evicting the oldest when full.
+     *
+     * [sequenceId] is the identity the composite dedupes on; `null` means the caller is not
+     * [VLog] and the entry can only ever be matched by being kept.
+     */
+    fun record(
+        level: DiagnosticsLevel,
+        category: String,
+        message: String,
+        at: Long,
+        sequenceId: Long? = null,
+    ) {
+        val entry = DiagnosticsLogEntry(at, level, category, message, sequenceId)
+        synchronized(lock) {
+            entries.addLast(entry)
+            while (entries.size > capacity) entries.removeFirst()
+        }
+    }
+
+    /** Drop everything captured so far. */
+    fun clear() {
+        synchronized(lock) { entries.clear() }
+    }
+
+    override suspend fun recentEntries(sinceMillis: Long?, limit: Int): SourceResult {
+        if (limit <= 0) return SourceResult.Available(emptyList())
+
+        val snapshot = synchronized(lock) { entries.toList() }
+        val filtered = if (sinceMillis == null) snapshot else snapshot.filter { it.timeMillis >= sinceMillis }
+        // coerce first: `takeLast(Int.MAX_VALUE)` would try to size a list to Int.MAX_VALUE.
+        return SourceResult.Available(filtered.takeLast(limit.coerceAtMost(filtered.size)))
+    }
+
+    companion object {
+        /** Plan §11 limitation 4 — the in-process capture window. */
+        const val DEFAULT_CAPACITY: Int = 500
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/diagnostics/VLog.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/diagnostics/VLog.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.random.Random
 
 /**
  * Purpose: Feature #164 WI-3 — the ONE logging facade for vreader's own Android code. Every
@@ -34,6 +35,14 @@ import java.util.concurrent.atomic.AtomicLong
  * - **The sequence id is stamped as a LEADING marker** ([VLogMarker]) on the forwarded message
  *   only. logd truncates the tail, so a leading token survives; the ring's copy never carries it,
  *   and WI-1's parser strips it, so no marker can reach the viewer or the export.
+ * - **The id is namespaced by a per-LAUNCH nonce, not a bare counter** (Gate-4 High). logd retains
+ *   entries across process launches — that prior-launch trail is the one thing the platform log
+ *   offers that the ring cannot. A counter restarting at 1 every launch would hand the *current*
+ *   process's first entries the same ids the *previous* launch already wrote to logcat, and the
+ *   composite (which prefers the ring on a collision) would then DROP exactly those pre-crash
+ *   breadcrumbs. So the id is `nonce | counter`: the high [NONCE_BITS] carry a random per-launch
+ *   value, the low [COUNTER_BITS] an atomic counter. Monotonic within a launch (the nonce is
+ *   fixed), and ~1-in-2-million to repeat across two launches instead of guaranteed to.
  * - **A `Throwable` is rendered INTO the message** rather than handed to `Log`'s throwable
  *   overload. Both representations must be byte-identical or the composite would surface two
  *   different-looking copies of one event; passing it to `Log` as well would print the trace twice.
@@ -49,11 +58,29 @@ object VLog {
     @Volatile
     private var clock: () -> Long = System::currentTimeMillis
 
-    private val sequence = AtomicLong(0L)
+    private val counter = AtomicLong(0L)
 
-    /** Wire the capture floor. Called once from `VReaderApp.onCreate`. */
-    fun install(sink: RingBufferDiagnosticsSource, clock: () -> Long = System::currentTimeMillis) {
+    @Volatile
+    private var launchNonce: Long = randomLaunchNonce()
+
+    /**
+     * Wire the capture floor. Called once from `VReaderApp.onCreate`.
+     *
+     * [launchNonce] exists so a test can simulate two process launches deterministically; leave it
+     * defaulted in production, where a fresh random value per launch is the whole point.
+     */
+    fun install(
+        sink: RingBufferDiagnosticsSource,
+        clock: () -> Long = System::currentTimeMillis,
+        launchNonce: Long = randomLaunchNonce(),
+    ) {
         this.clock = clock
+        this.launchNonce = launchNonce and NONCE_MASK
+        // The counter restarts because the nonce it is namespaced by just changed — a new nonce IS
+        // a new id space. This is also what makes a two-launch test faithful in one JVM: without
+        // the reset, the second "launch" would keep counting up and could never collide, so the
+        // test would pass against the very defect it exists to catch.
+        counter.set(0L)
         this.sink = sink
     }
 
@@ -62,6 +89,9 @@ object VLog {
         sink = null
         clock = System::currentTimeMillis
     }
+
+    /** Never 0 — a zero nonce would make this launch indistinguishable from a bare counter. */
+    private fun randomLaunchNonce(): Long = Random.nextLong(1L, NONCE_MASK + 1L)
 
     fun d(category: DiagnosticsCategory, origin: String, message: String) =
         emit(DiagnosticsLevel.DEBUG, category, origin, message, null)
@@ -84,7 +114,7 @@ object VLog {
         message: String,
         t: Throwable?,
     ) {
-        val sequenceId = sequence.incrementAndGet()
+        val sequenceId = (launchNonce shl COUNTER_BITS) or (counter.incrementAndGet() and COUNTER_MASK)
         val body = buildString {
             append('[').append(origin).append("] ").append(message)
             if (t != null) append('\n').append(stackTraceOf(t))
@@ -113,4 +143,14 @@ object VLog {
         PrintWriter(writer).use { t.printStackTrace(it) }
         return writer.toString().trimEnd()
     }
+
+    /**
+     * 21 nonce bits + 42 counter bits = 63, so every id is a positive `Long` and renders as a
+     * decimal the WI-1 marker regex (`«v(\d+)»`) accepts unchanged. 2^42 entries in one launch is
+     * unreachable, so the counter cannot wrap into a neighbouring nonce's namespace.
+     */
+    internal const val COUNTER_BITS: Int = 42
+    internal const val NONCE_BITS: Int = 21
+    private const val COUNTER_MASK: Long = (1L shl COUNTER_BITS) - 1L
+    private const val NONCE_MASK: Long = (1L shl NONCE_BITS) - 1L
 }

--- a/android/app/src/main/kotlin/com/vreader/app/diagnostics/VLog.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/diagnostics/VLog.kt
@@ -44,6 +44,13 @@ import kotlin.random.Random
  *   breadcrumbs. So the id is `nonce | counter`: the high [NONCE_BITS] carry a random per-launch
  *   value, the low [COUNTER_BITS] an atomic counter. Monotonic within a launch (the nonce is
  *   fixed), and ~1-in-2-million to repeat across two launches instead of guaranteed to.
+ *
+ *   ACCEPTED RESIDUAL (Gate-4 round 3): that ~1-in-2^21 repeat is not eliminated. Making ids
+ *   collision-FREE across launches needs durable state — a counter or epoch persisted to disk and
+ *   read back at start-up — which puts an I/O dependency and a failure mode inside a logging
+ *   facade for a bounded, tiny loss: on a repeat, a handful of prior-launch logcat entries whose
+ *   counters overlap the current ring's are deduped away. That is strictly better than the
+ *   pre-fix behavior, where the same loss happened on EVERY launch.
  * - **A `Throwable` is rendered INTO the message** rather than handed to `Log`'s throwable
  *   overload. Both representations must be byte-identical or the composite would surface two
  *   different-looking copies of one event; passing it to `Log` as well would print the trace twice.
@@ -53,25 +60,28 @@ import kotlin.random.Random
  */
 object VLog {
 
-    @Volatile
-    private var sink: RingBufferDiagnosticsSource? = null
-
-    @Volatile
-    private var clock: () -> Long = System::currentTimeMillis
-
     /**
-     * A nonce and ITS OWN counter, swapped as one immutable unit (Gate-4 round-2 High). Holding
-     * them as two independent fields (`@Volatile` nonce + shared `AtomicLong`) made the pair
-     * non-atomic: an `emit` could read the old nonce, be descheduled while `install` reset the
-     * counter, and then issue `oldNonce|1` — a duplicate of an id the old generation already used,
-     * which the composite would silently collapse into one entry. Each generation owning its own
-     * counter makes that interleaving unrepresentable.
+     * Everything one `emit` needs, published as ONE immutable object (Gate-4 rounds 2 and 3).
+     *
+     * Held as separate fields it was not safe twice over. First, a `@Volatile` nonce beside a
+     * shared `AtomicLong` was not an atomic pair: an emit could read the old nonce, be descheduled
+     * while install reset the counter, then issue `oldNonce|1` — a duplicate of an id already used,
+     * which the composite would silently collapse. Giving each installation its own counter fixed
+     * that. Second, `sink`, `clock` and the counter were still three independent writes, so a
+     * concurrent emit could pair a new counter with the old sink. One reference, one read, no pairs.
      */
-    private class Generation(val nonce: Long) {
+    private class Installation(
+        val sink: RingBufferDiagnosticsSource?,
+        val clock: () -> Long,
+        val nonce: Long,
+    ) {
         val counter = AtomicLong(0L)
     }
 
-    private val generation = AtomicReference(Generation(randomLaunchNonce()))
+    private val installed = AtomicReference(uninstalledState())
+
+    private fun uninstalledState() =
+        Installation(sink = null, clock = System::currentTimeMillis, nonce = randomLaunchNonce())
 
     /**
      * Wire the capture floor. Called once from `VReaderApp.onCreate`.
@@ -84,19 +94,16 @@ object VLog {
         clock: () -> Long = System::currentTimeMillis,
         launchNonce: Long = randomLaunchNonce(),
     ) {
-        this.clock = clock
         // A new nonce IS a new id space, so it arrives with a counter of its own rather than
         // resetting a shared one. This is also what makes a two-launch test faithful inside one
         // JVM: without the restart the second "launch" would keep counting up and could never
         // collide, so the test would pass against the very defect it exists to catch.
-        generation.set(Generation(launchNonce and NONCE_MASK))
-        this.sink = sink
+        installed.set(Installation(sink, clock, launchNonce and NONCE_MASK))
     }
 
     /** Test-only: return to the uninstalled state so a global object cannot leak across tests. */
     internal fun uninstall() {
-        sink = null
-        clock = System::currentTimeMillis
+        installed.set(uninstalledState())
     }
 
     /** Never 0 — a zero nonce would make this launch indistinguishable from a bare counter. */
@@ -123,12 +130,14 @@ object VLog {
         message: String,
         t: Throwable?,
     ) {
-        val sequenceId = nextSequenceId()
+        // ONE snapshot: nonce, counter, sink and clock can never come from different installations.
+        val state = installed.get()
+        val sequenceId = (state.nonce shl COUNTER_BITS) or (state.counter.incrementAndGet() and COUNTER_MASK)
         val body = buildString {
             append('[').append(origin).append("] ").append(message)
             if (t != null) append('\n').append(stackTraceOf(t))
         }
-        sink?.record(level, category.tag, body, clock(), sequenceId)
+        state.sink?.record(level, category.tag, body, state.clock(), sequenceId)
         forward(level, category.tag, VLogMarker.encode(sequenceId) + body)
     }
 
@@ -145,12 +154,6 @@ object VLog {
             DiagnosticsLevel.WARN -> Log.w(tag, payload)
             DiagnosticsLevel.ERROR, DiagnosticsLevel.ASSERT -> Log.e(tag, payload)
         }
-    }
-
-    /** ONE snapshot of the generation, so nonce and counter can never come from different ones. */
-    private fun nextSequenceId(): Long {
-        val current = generation.get()
-        return (current.nonce shl COUNTER_BITS) or (current.counter.incrementAndGet() and COUNTER_MASK)
     }
 
     private fun stackTraceOf(t: Throwable): String {

--- a/android/app/src/main/kotlin/com/vreader/app/diagnostics/VLog.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/diagnostics/VLog.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.random.Random
 
 /**
@@ -58,10 +59,19 @@ object VLog {
     @Volatile
     private var clock: () -> Long = System::currentTimeMillis
 
-    private val counter = AtomicLong(0L)
+    /**
+     * A nonce and ITS OWN counter, swapped as one immutable unit (Gate-4 round-2 High). Holding
+     * them as two independent fields (`@Volatile` nonce + shared `AtomicLong`) made the pair
+     * non-atomic: an `emit` could read the old nonce, be descheduled while `install` reset the
+     * counter, and then issue `oldNonce|1` — a duplicate of an id the old generation already used,
+     * which the composite would silently collapse into one entry. Each generation owning its own
+     * counter makes that interleaving unrepresentable.
+     */
+    private class Generation(val nonce: Long) {
+        val counter = AtomicLong(0L)
+    }
 
-    @Volatile
-    private var launchNonce: Long = randomLaunchNonce()
+    private val generation = AtomicReference(Generation(randomLaunchNonce()))
 
     /**
      * Wire the capture floor. Called once from `VReaderApp.onCreate`.
@@ -75,12 +85,11 @@ object VLog {
         launchNonce: Long = randomLaunchNonce(),
     ) {
         this.clock = clock
-        this.launchNonce = launchNonce and NONCE_MASK
-        // The counter restarts because the nonce it is namespaced by just changed — a new nonce IS
-        // a new id space. This is also what makes a two-launch test faithful in one JVM: without
-        // the reset, the second "launch" would keep counting up and could never collide, so the
-        // test would pass against the very defect it exists to catch.
-        counter.set(0L)
+        // A new nonce IS a new id space, so it arrives with a counter of its own rather than
+        // resetting a shared one. This is also what makes a two-launch test faithful inside one
+        // JVM: without the restart the second "launch" would keep counting up and could never
+        // collide, so the test would pass against the very defect it exists to catch.
+        generation.set(Generation(launchNonce and NONCE_MASK))
         this.sink = sink
     }
 
@@ -114,7 +123,7 @@ object VLog {
         message: String,
         t: Throwable?,
     ) {
-        val sequenceId = (launchNonce shl COUNTER_BITS) or (counter.incrementAndGet() and COUNTER_MASK)
+        val sequenceId = nextSequenceId()
         val body = buildString {
             append('[').append(origin).append("] ").append(message)
             if (t != null) append('\n').append(stackTraceOf(t))
@@ -136,6 +145,12 @@ object VLog {
             DiagnosticsLevel.WARN -> Log.w(tag, payload)
             DiagnosticsLevel.ERROR, DiagnosticsLevel.ASSERT -> Log.e(tag, payload)
         }
+    }
+
+    /** ONE snapshot of the generation, so nonce and counter can never come from different ones. */
+    private fun nextSequenceId(): Long {
+        val current = generation.get()
+        return (current.nonce shl COUNTER_BITS) or (current.counter.incrementAndGet() and COUNTER_MASK)
     }
 
     private fun stackTraceOf(t: Throwable): String {

--- a/android/app/src/main/kotlin/com/vreader/app/diagnostics/VLog.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/diagnostics/VLog.kt
@@ -1,0 +1,116 @@
+package com.vreader.app.diagnostics
+
+import android.util.Log
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Purpose: Feature #164 WI-3 — the ONE logging facade for vreader's own Android code. Every
+ * deliberate log call goes through here; nothing else in `app/src/main` may reference
+ * `android.util.Log` (enforced by `scripts/__tests__/check-android-log-containment.sh`).
+ *
+ * Each call does exactly two things:
+ * 1. records into the installed [RingBufferDiagnosticsSource] (the capture floor), and
+ * 2. forwards to `android.util.Log` (so logcat, `adb`, and bug reports are unchanged in
+ *    substance — the plan's §10 backward-compat guarantee).
+ *
+ * Key decisions:
+ * - **The logcat TAG becomes the category, not the class** (`"Reader"`, not `"FoliateBridge"`).
+ *   Deliberate and breaking for developers: it is what lets logcat-sourced and ring-sourced
+ *   entries share one category vocabulary, which is what the designed chip row is built on. The
+ *   class name is preserved as a `[ClassName]` prefix on the message, so grep-by-class still
+ *   works. `adb logcat -s FoliateBridge` must become `adb logcat -s Reader`.
+ * - **`origin` is an explicit parameter, not derived from the stack.** Walking
+ *   `Throwable().stackTrace` to name the caller looks tidier and is wrong in the places that
+ *   matter: a call from a lambda or an anonymous `object :` yields a synthetic frame
+ *   (`FoliateBridge$attach$2`), a call from a top-level function yields `BookShareIntentKt`, and
+ *   R8 renaming would degrade the prefix to `a`. Each migrated site already had a `TAG` constant
+ *   with exactly the right string; passing it is deterministic, greppable, and minification-proof.
+ *   This is a documented widening of the plan's §4.1 signature.
+ * - **Forwarding is UNCONDITIONAL; recording is not.** Before `install()` there is nowhere to
+ *   record, but there is still somewhere to log — and silently swallowing entries logged during
+ *   app start-up would be a regression against today's behavior, not a neutral no-op.
+ * - **The sequence id is stamped as a LEADING marker** ([VLogMarker]) on the forwarded message
+ *   only. logd truncates the tail, so a leading token survives; the ring's copy never carries it,
+ *   and WI-1's parser strips it, so no marker can reach the viewer or the export.
+ * - **A `Throwable` is rendered INTO the message** rather than handed to `Log`'s throwable
+ *   overload. Both representations must be byte-identical or the composite would surface two
+ *   different-looking copies of one event; passing it to `Log` as well would print the trace twice.
+ *
+ * @coordinates-with RingBufferDiagnosticsSource.kt, DiagnosticsCategory.kt, DiagnosticsLogEntry.kt
+ *   (VLogMarker), LogcatLineParser.kt
+ */
+object VLog {
+
+    @Volatile
+    private var sink: RingBufferDiagnosticsSource? = null
+
+    @Volatile
+    private var clock: () -> Long = System::currentTimeMillis
+
+    private val sequence = AtomicLong(0L)
+
+    /** Wire the capture floor. Called once from `VReaderApp.onCreate`. */
+    fun install(sink: RingBufferDiagnosticsSource, clock: () -> Long = System::currentTimeMillis) {
+        this.clock = clock
+        this.sink = sink
+    }
+
+    /** Test-only: return to the uninstalled state so a global object cannot leak across tests. */
+    internal fun uninstall() {
+        sink = null
+        clock = System::currentTimeMillis
+    }
+
+    fun d(category: DiagnosticsCategory, origin: String, message: String) =
+        emit(DiagnosticsLevel.DEBUG, category, origin, message, null)
+
+    fun i(category: DiagnosticsCategory, origin: String, message: String) =
+        emit(DiagnosticsLevel.INFO, category, origin, message, null)
+
+    fun w(category: DiagnosticsCategory, origin: String, message: String, t: Throwable? = null) =
+        emit(DiagnosticsLevel.WARN, category, origin, message, t)
+
+    fun e(category: DiagnosticsCategory, origin: String, message: String, t: Throwable? = null) =
+        emit(DiagnosticsLevel.ERROR, category, origin, message, t)
+
+    // ------------------------------------------------------------------ internals
+
+    private fun emit(
+        level: DiagnosticsLevel,
+        category: DiagnosticsCategory,
+        origin: String,
+        message: String,
+        t: Throwable?,
+    ) {
+        val sequenceId = sequence.incrementAndGet()
+        val body = buildString {
+            append('[').append(origin).append("] ").append(message)
+            if (t != null) append('\n').append(stackTraceOf(t))
+        }
+        sink?.record(level, category.tag, body, clock(), sequenceId)
+        forward(level, category.tag, VLogMarker.encode(sequenceId) + body)
+    }
+
+    /**
+     * `ASSERT` is unreachable from the public API above and is mapped to `Log.e` rather than
+     * `Log.wtf` on purpose — `wtf` can be configured to terminate the process, which is not a
+     * behavior a diagnostics facade should be able to trigger.
+     */
+    private fun forward(level: DiagnosticsLevel, tag: String, payload: String) {
+        when (level) {
+            DiagnosticsLevel.VERBOSE -> Log.v(tag, payload)
+            DiagnosticsLevel.DEBUG -> Log.d(tag, payload)
+            DiagnosticsLevel.INFO -> Log.i(tag, payload)
+            DiagnosticsLevel.WARN -> Log.w(tag, payload)
+            DiagnosticsLevel.ERROR, DiagnosticsLevel.ASSERT -> Log.e(tag, payload)
+        }
+    }
+
+    private fun stackTraceOf(t: Throwable): String {
+        val writer = StringWriter()
+        PrintWriter(writer).use { t.printStackTrace(it) }
+        return writer.toString().trimEnd()
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/PdfDocument.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/PdfDocument.kt
@@ -12,7 +12,8 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.pdf.PdfRenderer
 import android.os.ParcelFileDescriptor
-import android.util.Log
+import com.vreader.app.diagnostics.DiagnosticsCategory
+import com.vreader.app.diagnostics.VLog
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
@@ -98,7 +99,7 @@ class PdfDocument private constructor(
                 fd?.let { runCatching { it.close() } }
                 PdfOpenResult.Corrupt
             } catch (e: Throwable) {
-                Log.w(TAG, "unexpected error opening PDF; treating as corrupt", e)
+                VLog.w(DiagnosticsCategory.READER, TAG, "unexpected error opening PDF; treating as corrupt", e)
                 fd?.let { runCatching { it.close() } }
                 PdfOpenResult.Corrupt
             }

--- a/android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt
@@ -71,6 +71,8 @@ import com.vreader.app.annotations.SelectionPopoverActions
 import com.vreader.app.annotations.SelectionPopoverViewModel
 import com.vreader.app.data.Book
 import com.vreader.app.data.LibraryRepository
+import com.vreader.app.diagnostics.DiagnosticsCategory
+import com.vreader.app.diagnostics.VLog
 import com.vreader.app.reader.chrome.ReaderChromeState
 import com.vreader.app.reader.chrome.ReaderSheet
 import com.vreader.app.reader.nav.BookmarkDateRenderer
@@ -753,7 +755,14 @@ class ReaderActivity : AppCompatActivity() {
                 val prefs = EpubPreferences(scroll = settings.layout == com.vreader.app.reader.settings.ReaderLayout.Scroll) +
                     settings.toEpubPreferences()
                 runCatching { nav.submitPreferences(prefs) }
-                    .onFailure { android.util.Log.w("ReaderActivity", "submitPreferences failed; display change not applied", it) }
+                    .onFailure {
+                        VLog.w(
+                            DiagnosticsCategory.READER,
+                            "ReaderActivity",
+                            "submitPreferences failed; display change not applied",
+                            it,
+                        )
+                    }
                 // feature #131 WI-7b — a `submitPreferences` reflow can drop the injected decorations
                 // (a CSS/typography reflow re-renders the resource DOM). Schedule a probe-gated re-inject
                 // (on the dedicated job — never suspend this settings collector) so the interlinear

--- a/android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateBridge.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateBridge.kt
@@ -16,6 +16,8 @@ import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewClientCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
+import com.vreader.app.diagnostics.DiagnosticsCategory
+import com.vreader.app.diagnostics.VLog
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -90,7 +92,11 @@ class FoliateBridge(
                 if (m.messageLevel() == android.webkit.ConsoleMessage.MessageLevel.ERROR ||
                     m.messageLevel() == android.webkit.ConsoleMessage.MessageLevel.WARNING
                 ) {
-                    android.util.Log.w("FoliateBridge", "console[${m.messageLevel()}]: ${m.message()} @${m.sourceId()}:${m.lineNumber()}")
+                    VLog.w(
+                        DiagnosticsCategory.READER,
+                        "FoliateBridge",
+                        "console[${m.messageLevel()}]: ${m.message()} @${m.sourceId()}:${m.lineNumber()}",
+                    )
                 }
                 return true
             }

--- a/android/app/src/main/kotlin/com/vreader/app/reader/share/BookShareIntent.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/share/BookShareIntent.kt
@@ -15,9 +15,10 @@ import android.content.ActivityNotFoundException
 import android.content.ClipData
 import android.content.Context
 import android.content.Intent
-import android.util.Log
 import androidx.core.content.FileProvider
 import com.vreader.app.data.Book
+import com.vreader.app.diagnostics.DiagnosticsCategory
+import com.vreader.app.diagnostics.VLog
 import vreader.contracts.BookFormat
 import java.io.File
 
@@ -45,7 +46,7 @@ fun shareBookFileIntent(context: Context, book: Book): Intent? {
         FileProvider.getUriForFile(context, authority, file)
     } catch (e: IllegalArgumentException) {
         // FileProvider throws when the file is outside every configured <paths> root — reject.
-        Log.w(TAG, "file not shareable via FileProvider (outside grant scope)", e)
+        VLog.w(DiagnosticsCategory.LIBRARY, TAG, "file not shareable via FileProvider (outside grant scope)", e)
         return null
     }
 
@@ -73,7 +74,7 @@ fun shareBook(context: Context, book: Book) {
     try {
         context.startActivity(chooser)
     } catch (e: ActivityNotFoundException) {
-        Log.w(TAG, "no activity to receive the shared book file", e)
+        VLog.w(DiagnosticsCategory.LIBRARY, TAG, "no activity to receive the shared book file", e)
     }
 }
 

--- a/android/app/src/main/kotlin/com/vreader/app/search/SearchIndexCoordinator.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/search/SearchIndexCoordinator.kt
@@ -22,12 +22,13 @@
 // per-book failure is isolated and recorded as a retryable `failed` state (only if the book exists).
 package com.vreader.app.search
 
-import android.util.Log
 import com.vreader.app.data.Book
 import com.vreader.app.data.LibraryRepository
 import com.vreader.app.data.SearchDao
 import com.vreader.app.data.SearchIndexStateEntity
 import com.vreader.app.data.SearchStagingEntity
+import com.vreader.app.diagnostics.DiagnosticsCategory
+import com.vreader.app.diagnostics.VLog
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -154,7 +155,12 @@ class SearchIndexCoordinator(
             // Any other failure (e.g. an FK-constraint loss to a concurrent delete) is a benign no-op
             // for collector availability, but log it so a persistent DB/programming fault is observable
             // (Gate-4 round-2 follow-up) rather than silently swallowed.
-            Log.w(TAG, "search-index terminal-state write for $bookKey ($status) failed; skipping", e)
+            VLog.w(
+                DiagnosticsCategory.LIBRARY,
+                TAG,
+                "search-index terminal-state write for $bookKey ($status) failed; skipping",
+                e,
+            )
         }
     }
 

--- a/android/app/src/test/kotlin/com/vreader/app/diagnostics/CompositeDiagnosticsSourceTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/diagnostics/CompositeDiagnosticsSourceTest.kt
@@ -1,0 +1,275 @@
+package com.vreader.app.diagnostics
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Feature #164 WI-3 — [CompositeDiagnosticsSource].
+ *
+ * Two contracts carry the whole design and are asserted in BOTH directions:
+ *
+ *  1. **Merge, don't choose.** Whenever the primary (logcat) is `Available` — INCLUDING
+ *     `Available(emptyList())` — the ring's entries are merged in, never hidden. The rejected v1
+ *     "primary else floor" design failed exactly here: a sparse-but-readable logcat suppressed the
+ *     ring entirely.
+ *  2. **Dedupe on identity, never on text.** The key is the VLog sequence id. Deduping on
+ *     `(time, tag, message)` would collapse two genuinely distinct events that happen to share
+ *     byte-identical text and timestamp — a realistic shape for a repeated handled condition in a
+ *     tight loop. Both halves are asserted: the twin appears once, the look-alikes both survive.
+ */
+class CompositeDiagnosticsSourceTest {
+
+    private fun entry(
+        time: Long,
+        message: String,
+        sequenceId: Long? = null,
+        category: String = "Reader",
+        level: DiagnosticsLevel = DiagnosticsLevel.WARN,
+    ) = DiagnosticsLogEntry(time, level, category, message, sequenceId)
+
+    private class FakeSource(
+        private val result: SourceResult = SourceResult.Available(emptyList()),
+        private val error: Throwable? = null,
+    ) : DiagnosticsLogSource {
+        var calls = 0
+        var lastSince: Long? = null
+        var lastLimit: Int = Int.MIN_VALUE
+
+        override suspend fun recentEntries(sinceMillis: Long?, limit: Int): SourceResult {
+            calls++
+            lastSince = sinceMillis
+            lastLimit = limit
+            error?.let { throw it }
+            return result
+        }
+    }
+
+    private fun available(vararg entries: DiagnosticsLogEntry) = SourceResult.Available(entries.toList())
+
+    private suspend fun merge(
+        primary: DiagnosticsLogSource,
+        secondary: DiagnosticsLogSource,
+        sinceMillis: Long? = null,
+        limit: Int = 1_000,
+    ): SourceResult = CompositeDiagnosticsSource(primary, secondary).recentEntries(sinceMillis, limit)
+
+    private fun SourceResult.entries(): List<DiagnosticsLogEntry> {
+        assertTrue("expected Available, got $this", this is SourceResult.Available)
+        return (this as SourceResult.Available).entries
+    }
+
+    // ---------------------------------------------------------------- merge semantics
+
+    @Test
+    fun mergesBothSourcesWhenThePrimaryIsAvailable() = runTest {
+        val logcat = FakeSource(available(entry(200, "from logcat")))
+        val ring = FakeSource(available(entry(100, "from ring", sequenceId = 1L)))
+
+        assertEquals(
+            listOf("from ring", "from logcat"),
+            merge(logcat, ring).entries().map { it.message },
+        )
+    }
+
+    /** The v1-design regression: a readable-but-empty logcat must NOT hide the ring. */
+    @Test
+    fun anEmptyButAvailablePrimaryStillYieldsTheRingEntries() = runTest {
+        val logcat = FakeSource(SourceResult.Available(emptyList()))
+        val ring = FakeSource(available(entry(100, "breadcrumb", sequenceId = 1L)))
+
+        assertEquals(listOf("breadcrumb"), merge(logcat, ring).entries().map { it.message })
+    }
+
+    /** The other half of the same regression: a SPARSE logcat must not hide the ring either. */
+    @Test
+    fun aPartiallyPopulatedPrimaryDoesNotHideRingEntries() = runTest {
+        val logcat = FakeSource(available(entry(50, "framework line")))
+        val ring = FakeSource(
+            available(entry(60, "ours a", sequenceId = 1L), entry(70, "ours b", sequenceId = 2L)),
+        )
+
+        assertEquals(
+            listOf("framework line", "ours a", "ours b"),
+            merge(logcat, ring).entries().map { it.message },
+        )
+    }
+
+    @Test
+    fun returnsOnlySecondaryWhenThePrimaryIsUnavailable() = runTest {
+        val logcat = FakeSource(SourceResult.Unavailable("exec denied"))
+        val ring = FakeSource(available(entry(100, "floor", sequenceId = 1L)))
+
+        assertEquals(listOf("floor"), merge(logcat, ring).entries().map { it.message })
+    }
+
+    @Test
+    fun returnsOnlyPrimaryWhenTheSecondaryIsUnavailable() = runTest {
+        val logcat = FakeSource(available(entry(100, "platform")))
+        val ring = FakeSource(SourceResult.Unavailable("no sink"))
+
+        assertEquals(listOf("platform"), merge(logcat, ring).entries().map { it.message })
+    }
+
+    @Test
+    fun bothUnavailableReportsUnavailableCitingBothReasons() = runTest {
+        val result = merge(
+            FakeSource(SourceResult.Unavailable("logcat: denied")),
+            FakeSource(SourceResult.Unavailable("ring: absent")),
+        )
+
+        assertTrue("expected Unavailable, got $result", result is SourceResult.Unavailable)
+        val reason = (result as SourceResult.Unavailable).reason
+        assertTrue(reason, reason.contains("logcat: denied"))
+        assertTrue(reason, reason.contains("ring: absent"))
+    }
+
+    // ---------------------------------------------------------------- dedupe (identity, not text)
+
+    @Test
+    fun anEventPresentInBothSourcesAppearsExactlyOnce() = runTest {
+        val twinTime = 1_000L
+        val logcat = FakeSource(available(entry(twinTime, "[PdfDocument] corrupt", sequenceId = 42L)))
+        val ring = FakeSource(available(entry(twinTime, "[PdfDocument] corrupt", sequenceId = 42L)))
+
+        val merged = merge(logcat, ring).entries()
+        assertEquals(1, merged.size)
+        assertEquals(42L, merged.single().sequenceId)
+    }
+
+    /**
+     * The assertion that a `(time, tag, message)` dedupe cannot pass. Two distinct events, same
+     * text, same timestamp, different ids — both must survive.
+     */
+    @Test
+    fun twoDistinctEntriesWithByteIdenticalTextAndTimestampBothSurvive() = runTest {
+        val t = 5_000L
+        val text = "[SearchIndexCoordinator] terminal-state write failed; skipping"
+        val logcat = FakeSource(available(entry(t, text, sequenceId = 7L), entry(t, text, sequenceId = 8L)))
+        val ring = FakeSource(SourceResult.Available(emptyList()))
+
+        val merged = merge(logcat, ring).entries()
+        assertEquals(2, merged.size)
+        assertEquals(listOf(7L, 8L), merged.mapNotNull { it.sequenceId })
+    }
+
+    @Test
+    fun entriesWithoutASequenceIdAreNeverCollapsedEvenWhenIdentical() = runTest {
+        val t = 900L
+        val logcat = FakeSource(available(entry(t, "chromium said no"), entry(t, "chromium said no")))
+        val ring = FakeSource(available(entry(t, "chromium said no")))
+
+        assertEquals(3, merge(logcat, ring).entries().size)
+    }
+
+    /**
+     * logd truncates an over-long payload at 4068 bytes; the ring holds the entry intact. When the
+     * same id arrives from both, the RING copy wins — deduping to the truncated twin would lose
+     * exactly the tail of a stack trace, which is the part worth having.
+     */
+    @Test
+    fun theRingCopyWinsACollisionSoTruncationIsNotInherited() = runTest {
+        val full = "[FoliateBridge] " + "z".repeat(5_000)
+        val logcat = FakeSource(available(entry(10L, full.take(4_068), sequenceId = 3L)))
+        val ring = FakeSource(available(entry(10L, full, sequenceId = 3L)))
+
+        assertEquals(full, merge(logcat, ring).entries().single().message)
+    }
+
+    @Test
+    fun aRingEntryWhoseLogcatTwinWasDroppedStillSurfaces() = runTest {
+        val logcat = FakeSource(available(entry(10L, "kept", sequenceId = 1L)))
+        val ring = FakeSource(available(entry(10L, "kept", sequenceId = 1L), entry(20L, "dropped by logd", sequenceId = 2L)))
+
+        assertEquals(listOf("kept", "dropped by logd"), merge(logcat, ring).entries().map { it.message })
+    }
+
+    // ---------------------------------------------------------------- ordering + limits
+
+    @Test
+    fun mergedOutputIsOrderedOldestToNewestAcrossSources() = runTest {
+        val logcat = FakeSource(available(entry(30, "c"), entry(10, "a")))
+        val ring = FakeSource(available(entry(20, "b", sequenceId = 1L), entry(40, "d", sequenceId = 2L)))
+
+        assertEquals(listOf("a", "b", "c", "d"), merge(logcat, ring).entries().map { it.message })
+    }
+
+    @Test
+    fun limitClampsTheMergedResultToTheMostRecentEntries() = runTest {
+        val logcat = FakeSource(available(entry(10, "a"), entry(30, "c")))
+        val ring = FakeSource(available(entry(20, "b", sequenceId = 1L), entry(40, "d", sequenceId = 2L)))
+
+        assertEquals(listOf("c", "d"), merge(logcat, ring, limit = 2).entries().map { it.message })
+    }
+
+    @Test
+    fun zeroAndNegativeLimitYieldEmptyWithoutThrowing() = runTest {
+        val logcat = FakeSource(available(entry(10, "a")))
+        val ring = FakeSource(available(entry(20, "b", sequenceId = 1L)))
+
+        assertEquals(emptyList<DiagnosticsLogEntry>(), merge(logcat, ring, limit = 0).entries())
+        assertEquals(emptyList<DiagnosticsLogEntry>(), merge(logcat, ring, limit = -3).entries())
+    }
+
+    @Test
+    fun sinceMillisAndLimitAreForwardedToBothSources() = runTest {
+        val logcat = FakeSource(available())
+        val ring = FakeSource(available())
+
+        merge(logcat, ring, sinceMillis = 12_345L, limit = 77)
+
+        assertEquals(1, logcat.calls)
+        assertEquals(1, ring.calls)
+        assertEquals(12_345L, logcat.lastSince)
+        assertEquals(12_345L, ring.lastSince)
+        assertEquals(77, logcat.lastLimit)
+        assertEquals(77, ring.lastLimit)
+    }
+
+    // ---------------------------------------------------------------- failure containment
+
+    @Test
+    fun aThrowingPrimaryIsTreatedAsUnavailableAndNeverPropagates() = runTest {
+        val logcat = FakeSource(error = IOException("logcat exploded"))
+        val ring = FakeSource(available(entry(10L, "floor", sequenceId = 1L)))
+
+        assertEquals(listOf("floor"), merge(logcat, ring).entries().map { it.message })
+    }
+
+    @Test
+    fun aThrowingSecondaryIsTreatedAsUnavailableAndNeverPropagates() = runTest {
+        val logcat = FakeSource(available(entry(10L, "platform")))
+        val ring = FakeSource(error = IllegalStateException("ring exploded"))
+
+        assertEquals(listOf("platform"), merge(logcat, ring).entries().map { it.message })
+    }
+
+    @Test
+    fun bothThrowingReportsUnavailableRatherThanCrashing() = runTest {
+        val result = merge(
+            FakeSource(error = IOException("a")),
+            FakeSource(error = IOException("b")),
+        )
+        assertTrue("expected Unavailable, got $result", result is SourceResult.Unavailable)
+    }
+
+    /**
+     * Cancellation is NOT a source failure: swallowing it would break structured concurrency and
+     * leave a cancelled viewer load looking like a successful empty read.
+     */
+    @Test
+    fun cancellationStillPropagates() = runTest {
+        val logcat = FakeSource(error = CancellationException("viewer closed"))
+        val ring = FakeSource(available(entry(10L, "floor", sequenceId = 1L)))
+
+        try {
+            merge(logcat, ring)
+            throw AssertionError("CancellationException must propagate")
+        } catch (expected: CancellationException) {
+            assertEquals("viewer closed", expected.message)
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/diagnostics/RingBufferDiagnosticsSourceTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/diagnostics/RingBufferDiagnosticsSourceTest.kt
@@ -7,7 +7,9 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -169,26 +171,42 @@ class RingBufferDiagnosticsSourceTest {
     // ---------------------------------------------------------------- concurrency
 
     /**
-     * Writers from many threads while a reader loops. Two failure shapes are caught:
-     * a lost/duplicated entry (the set + size assertions), and a snapshot taken over a live
-     * collection (`ConcurrentModificationException` on the reader thread). Capacity is sized
-     * ABOVE the total so eviction cannot mask a lost write.
+     * Writers from many threads while a reader loops. Three failure shapes are caught: a
+     * lost/duplicated entry (the set + size assertions), a snapshot taken over a live collection
+     * (`ConcurrentModificationException` on the reader thread), and — the reason for the handshake
+     * below — the test itself quietly failing to overlap at all.
+     *
+     * A shared start latch alone does NOT establish "a read in flight": a legal scheduler may run
+     * every writer to completion before the reader takes its first snapshot, so a ring with its
+     * synchronisation removed could pass by luck. So the two sides are coupled: each writer emits
+     * one entry, then waits until the reader has observed a PARTIAL snapshot (strictly between
+     * empty and complete — a state that can only exist mid-write) before emitting the rest, and the
+     * run asserts that such an observation actually happened. The wait is deadline-bounded so a
+     * regression fails the assertion instead of hanging the suite.
+     *
+     * Capacity is sized ABOVE the total so eviction cannot mask a lost write.
      */
     @Test
     fun concurrentRecordLosesNothingWhileAReadIsInFlight() {
         val threads = 8
         val perThread = 500
-        val ring = RingBufferDiagnosticsSource(capacity = threads * perThread)
+        val total = threads * perThread
+        val ring = RingBufferDiagnosticsSource(capacity = total)
         val start = CountDownLatch(1)
         val stopReading = AtomicBoolean(false)
+        val partialSnapshots = AtomicLong(0)
         val readerFailure = AtomicReference<Throwable?>(null)
         val writerFailure = AtomicReference<Throwable?>(null)
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30)
 
         val reader = Thread {
             start.await()
             try {
                 while (!stopReading.get()) {
-                    runBlocking { ring.recentEntries(null, Int.MAX_VALUE) }
+                    val size = runBlocking {
+                        (ring.recentEntries(null, Int.MAX_VALUE) as SourceResult.Available).entries.size
+                    }
+                    if (size in 1 until total) partialSnapshots.incrementAndGet()
                 }
             } catch (t: Throwable) {
                 readerFailure.set(t)
@@ -198,7 +216,10 @@ class RingBufferDiagnosticsSourceTest {
             Thread {
                 start.await()
                 try {
-                    repeat(perThread) { i -> ring.put("$t-$i", at = i.toLong()) }
+                    ring.put("$t-0", at = 0L)
+                    // Hold until the reader has demonstrably read mid-write.
+                    while (partialSnapshots.get() == 0L && System.nanoTime() < deadline) Thread.yield()
+                    for (i in 1 until perThread) ring.put("$t-$i", at = i.toLong())
                 } catch (e: Throwable) {
                     writerFailure.set(e)
                 }
@@ -214,10 +235,14 @@ class RingBufferDiagnosticsSourceTest {
 
         assertNull("reader threw: ${readerFailure.get()}", readerFailure.get())
         assertNull("writer threw: ${writerFailure.get()}", writerFailure.get())
+        assertTrue(
+            "no snapshot overlapped the writes — this run proved nothing about concurrent reads",
+            partialSnapshots.get() > 0L,
+        )
 
         val got = entries(ring)
         val expected = (0 until threads).flatMap { t -> (0 until perThread).map { "$t-$it" } }.toSet()
-        assertEquals("lost or duplicated entries", threads * perThread, got.size)
+        assertEquals("lost or duplicated entries", total, got.size)
         assertEquals(expected, got.map { it.message }.toSet())
     }
 

--- a/android/app/src/test/kotlin/com/vreader/app/diagnostics/RingBufferDiagnosticsSourceTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/diagnostics/RingBufferDiagnosticsSourceTest.kt
@@ -200,6 +200,15 @@ class RingBufferDiagnosticsSourceTest {
      * than the whole write burst, so a cold reader reliably takes its first sample after the
      * writers are done. It therefore does warm-up snapshots on the empty ring first and releases
      * the writers only once it is looping hot.
+     *
+     * The design is VALIDATED, not assumed: with `synchronized` removed from the ring this test
+     * failed 4 runs out of 4 (an `ArrayIndexOutOfBoundsException` out of a concurrently-growing
+     * `ArrayDeque`); with it restored it passed 5 runs out of 5. A stricter phased handshake was
+     * considered and rejected — it is what the previous revision did, and it proved strictly LESS
+     * (it forced one partial observation rather than demonstrating sustained interleaving). The
+     * residual is scheduler dependence: on a pathologically starved runner the reader could miss
+     * the whole write burst, which fails the assertion LOUDLY rather than passing vacuously — the
+     * safe direction for a test whose job is to detect an unsynchronised ring.
      */
     @Test
     fun concurrentRecordLosesNothingWhileAReadIsInFlight() {
@@ -215,8 +224,8 @@ class RingBufferDiagnosticsSourceTest {
         val writerFailure = AtomicReference<Throwable?>(null)
 
         val reader = Thread {
-            start.await()
             try {
+                start.await()
                 var reads = 0
                 while (!stopReading.get()) {
                     val size = runBlocking {
@@ -233,9 +242,9 @@ class RingBufferDiagnosticsSourceTest {
         }
         val writers = (0 until threads).map { t ->
             Thread {
-                start.await()
-                readerWarm.await()
                 try {
+                    start.await()
+                    readerWarm.await()
                     repeat(perThread) { i -> ring.put("$t-$i", at = i.toLong()) }
                 } catch (e: Throwable) {
                     writerFailure.set(e)

--- a/android/app/src/test/kotlin/com/vreader/app/diagnostics/RingBufferDiagnosticsSourceTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/diagnostics/RingBufferDiagnosticsSourceTest.kt
@@ -3,13 +3,13 @@ package com.vreader.app.diagnostics
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.Collections
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -21,6 +21,15 @@ import java.util.concurrent.atomic.AtomicReference
  * capacity" is the invariant that keeps a long-running process from growing without bound.
  */
 class RingBufferDiagnosticsSourceTest {
+
+    /**
+     * Deliberately far below what a healthy run produces (hundreds), so the floor detects "the
+     * reader never got a look in" without becoming a load-sensitive flake.
+     */
+    private val MIN_INTERLEAVED_READS = 10
+
+    /** Snapshots the reader takes on the empty ring before the writers are released. */
+    private val WARMUP_READS = 200
 
     private fun entries(
         source: RingBufferDiagnosticsSource,
@@ -178,48 +187,56 @@ class RingBufferDiagnosticsSourceTest {
      *
      * A shared start latch alone does NOT establish "a read in flight": a legal scheduler may run
      * every writer to completion before the reader takes its first snapshot, so a ring with its
-     * synchronisation removed could pass by luck. So the two sides are coupled: each writer emits
-     * one entry, then waits until the reader has observed a PARTIAL snapshot (strictly between
-     * empty and complete — a state that can only exist mid-write) before emitting the rest, and the
-     * run asserts that such an observation actually happened. The wait is deadline-bounded so a
-     * regression fails the assertion instead of hanging the suite.
+     * synchronisation removed could pass by luck. The run therefore RECORDS how many DISTINCT
+     * intermediate sizes the reader observed (strictly between empty and complete) and asserts a
+     * floor. One intermediate size proves only that a read happened early; many distinct ones can
+     * only be produced by reads interleaved through the write stream. Capacity equals the total, so
+     * no eviction can manufacture an intermediate size after the writers finish.
      *
-     * Capacity is sized ABOVE the total so eviction cannot mask a lost write.
+     * The earlier revision instead had writers spin on `Thread.yield()` until the reader signalled
+     * a partial observation. That coupling was CI-hostile (a scheduling hint, not a guarantee, with
+     * a 30s deadline) and proved less. What the reader genuinely needs is not a handshake per write
+     * but a WARM-UP: its first `runBlocking` snapshot pays coroutine/classload costs far larger
+     * than the whole write burst, so a cold reader reliably takes its first sample after the
+     * writers are done. It therefore does warm-up snapshots on the empty ring first and releases
+     * the writers only once it is looping hot.
      */
     @Test
     fun concurrentRecordLosesNothingWhileAReadIsInFlight() {
         val threads = 8
-        val perThread = 500
+        val perThread = 2_000
         val total = threads * perThread
         val ring = RingBufferDiagnosticsSource(capacity = total)
         val start = CountDownLatch(1)
+        val readerWarm = CountDownLatch(1)
         val stopReading = AtomicBoolean(false)
-        val partialSnapshots = AtomicLong(0)
+        val intermediateSizes = Collections.synchronizedSet(HashSet<Int>())
         val readerFailure = AtomicReference<Throwable?>(null)
         val writerFailure = AtomicReference<Throwable?>(null)
-        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30)
 
         val reader = Thread {
             start.await()
             try {
+                var reads = 0
                 while (!stopReading.get()) {
                     val size = runBlocking {
                         (ring.recentEntries(null, Int.MAX_VALUE) as SourceResult.Available).entries.size
                     }
-                    if (size in 1 until total) partialSnapshots.incrementAndGet()
+                    if (size in 1 until total) intermediateSizes.add(size)
+                    if (++reads == WARMUP_READS) readerWarm.countDown()
                 }
             } catch (t: Throwable) {
                 readerFailure.set(t)
+            } finally {
+                readerWarm.countDown()   // never strand the writers if the reader dies
             }
         }
         val writers = (0 until threads).map { t ->
             Thread {
                 start.await()
+                readerWarm.await()
                 try {
-                    ring.put("$t-0", at = 0L)
-                    // Hold until the reader has demonstrably read mid-write.
-                    while (partialSnapshots.get() == 0L && System.nanoTime() < deadline) Thread.yield()
-                    for (i in 1 until perThread) ring.put("$t-$i", at = i.toLong())
+                    repeat(perThread) { i -> ring.put("$t-$i", at = i.toLong()) }
                 } catch (e: Throwable) {
                     writerFailure.set(e)
                 }
@@ -233,11 +250,14 @@ class RingBufferDiagnosticsSourceTest {
         stopReading.set(true)
         reader.join(60_000)
 
+        writers.forEachIndexed { i, w -> assertFalse("writer $i still alive", w.isAlive) }
+        assertFalse("reader still alive", reader.isAlive)
         assertNull("reader threw: ${readerFailure.get()}", readerFailure.get())
         assertNull("writer threw: ${writerFailure.get()}", writerFailure.get())
         assertTrue(
-            "no snapshot overlapped the writes — this run proved nothing about concurrent reads",
-            partialSnapshots.get() > 0L,
+            "reads did not interleave with the writes (${intermediateSizes.size} distinct " +
+                "intermediate sizes) — this run proved nothing about concurrent reads",
+            intermediateSizes.size >= MIN_INTERLEAVED_READS,
         )
 
         val got = entries(ring)

--- a/android/app/src/test/kotlin/com/vreader/app/diagnostics/RingBufferDiagnosticsSourceTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/diagnostics/RingBufferDiagnosticsSourceTest.kt
@@ -1,0 +1,240 @@
+package com.vreader.app.diagnostics
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Feature #164 WI-3 — the in-process ring buffer: the capture floor that survives a platform
+ * policy revoking logcat (plan §2), and VLog's sink.
+ *
+ * The eviction assertions run at capacity+1 AND capacity*3 on purpose: an implementation that
+ * evicts one entry per overflow passes the first and fails the second, and "never exceeds
+ * capacity" is the invariant that keeps a long-running process from growing without bound.
+ */
+class RingBufferDiagnosticsSourceTest {
+
+    private fun entries(
+        source: RingBufferDiagnosticsSource,
+        sinceMillis: Long? = null,
+        limit: Int = Int.MAX_VALUE,
+    ): List<DiagnosticsLogEntry> = runBlocking {
+        val result = source.recentEntries(sinceMillis, limit)
+        assertTrue("ring is never Unavailable, got $result", result is SourceResult.Available)
+        (result as SourceResult.Available).entries
+    }
+
+    private fun RingBufferDiagnosticsSource.put(message: String, at: Long, sequenceId: Long? = null) =
+        record(DiagnosticsLevel.INFO, "Reader", message, at, sequenceId)
+
+    // ---------------------------------------------------------------- ordering + fields
+
+    @Test
+    fun returnsOldestToNewestWithEveryFieldPreserved() {
+        val ring = RingBufferDiagnosticsSource(capacity = 8)
+        ring.record(DiagnosticsLevel.WARN, "Library", "first", 1_000L, 7L)
+        ring.record(DiagnosticsLevel.ERROR, "Sync", "second", 2_000L, 8L)
+
+        val got = entries(ring)
+        assertEquals(listOf("first", "second"), got.map { it.message })
+        assertEquals(DiagnosticsLevel.WARN, got[0].level)
+        assertEquals("Library", got[0].category)
+        assertEquals(1_000L, got[0].timeMillis)
+        assertEquals(7L, got[0].sequenceId)
+        assertEquals(DiagnosticsLevel.ERROR, got[1].level)
+        assertEquals(8L, got[1].sequenceId)
+    }
+
+    @Test
+    fun recordWithoutASequenceIdYieldsNull() {
+        val ring = RingBufferDiagnosticsSource(capacity = 4)
+        ring.put("no id", at = 1L)
+        assertNull(entries(ring).single().sequenceId)
+    }
+
+    @Test
+    fun emptyRingReturnsAvailableEmptyNotUnavailable() {
+        assertEquals(emptyList<DiagnosticsLogEntry>(), entries(RingBufferDiagnosticsSource(capacity = 4)))
+    }
+
+    // ---------------------------------------------------------------- eviction
+
+    @Test
+    fun evictsOldestFirstAtCapacityPlusOne() {
+        val ring = RingBufferDiagnosticsSource(capacity = 3)
+        repeat(4) { ring.put("m$it", at = it.toLong()) }
+
+        val got = entries(ring)
+        assertEquals(3, got.size)
+        assertEquals(listOf("m1", "m2", "m3"), got.map { it.message })
+    }
+
+    @Test
+    fun neverExceedsCapacityAtThreeTimesCapacity() {
+        val capacity = 5
+        val ring = RingBufferDiagnosticsSource(capacity = capacity)
+        repeat(capacity * 3) { ring.put("m$it", at = it.toLong()) }
+
+        val got = entries(ring)
+        assertEquals(capacity, got.size)
+        assertEquals((10..14).map { "m$it" }, got.map { it.message })
+    }
+
+    @Test
+    fun capacityOfOneKeepsOnlyTheNewest() {
+        val ring = RingBufferDiagnosticsSource(capacity = 1)
+        repeat(3) { ring.put("m$it", at = it.toLong()) }
+        assertEquals(listOf("m2"), entries(ring).map { it.message })
+    }
+
+    @Test
+    fun nonPositiveCapacityIsRejected() {
+        listOf(0, -1).forEach { bad ->
+            try {
+                RingBufferDiagnosticsSource(capacity = bad)
+                throw AssertionError("capacity=$bad must be rejected")
+            } catch (expected: IllegalArgumentException) {
+                // A silently-zero-capacity ring would drop every entry with no error — the exact
+                // silent-degradation shape the whole feature exists to avoid.
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------- limit
+
+    @Test
+    fun limitReturnsTheMostRecentEntriesStillOldestToNewest() {
+        val ring = RingBufferDiagnosticsSource(capacity = 10)
+        repeat(5) { ring.put("m$it", at = it.toLong()) }
+        assertEquals(listOf("m3", "m4"), entries(ring, limit = 2).map { it.message })
+    }
+
+    @Test
+    fun limitLargerThanTheBufferReturnsEverything() {
+        val ring = RingBufferDiagnosticsSource(capacity = 10)
+        repeat(3) { ring.put("m$it", at = it.toLong()) }
+        assertEquals(3, entries(ring, limit = 999).size)
+    }
+
+    @Test
+    fun zeroAndNegativeLimitReturnEmptyWithoutThrowing() {
+        val ring = RingBufferDiagnosticsSource(capacity = 10)
+        repeat(3) { ring.put("m$it", at = it.toLong()) }
+        assertEquals(emptyList<DiagnosticsLogEntry>(), entries(ring, limit = 0))
+        assertEquals(emptyList<DiagnosticsLogEntry>(), entries(ring, limit = -5))
+    }
+
+    // ---------------------------------------------------------------- sinceMillis
+
+    @Test
+    fun sinceMillisIsInclusiveAndAppliedBeforeLimit() {
+        val ring = RingBufferDiagnosticsSource(capacity = 10)
+        listOf(10L, 20L, 30L, 40L).forEach { ring.put("m$it", at = it) }
+
+        assertEquals(listOf("m20", "m30", "m40"), entries(ring, sinceMillis = 20L).map { it.message })
+        // limit applies to the FILTERED set, so the newest 2 at-or-after 20 are m30/m40.
+        assertEquals(listOf("m30", "m40"), entries(ring, sinceMillis = 20L, limit = 2).map { it.message })
+    }
+
+    @Test
+    fun sinceMillisNewerThanEverythingReturnsEmpty() {
+        val ring = RingBufferDiagnosticsSource(capacity = 4)
+        ring.put("old", at = 1L)
+        assertEquals(emptyList<DiagnosticsLogEntry>(), entries(ring, sinceMillis = 2L))
+    }
+
+    // ---------------------------------------------------------------- content edge cases
+
+    @Test
+    fun toleratesEmptyCjkAndVeryLongMessages() = runTest {
+        val ring = RingBufferDiagnosticsSource(capacity = 4)
+        val long = "x".repeat(200_000)
+        ring.record(DiagnosticsLevel.DEBUG, "", "", 1L)
+        ring.record(DiagnosticsLevel.DEBUG, "读者", "章节加载失败 — 第 3 章", 2L)
+        ring.record(DiagnosticsLevel.DEBUG, "Reader", long, 3L)
+
+        val got = (ring.recentEntries(null, Int.MAX_VALUE) as SourceResult.Available).entries
+        assertEquals("", got[0].category)
+        assertEquals("", got[0].message)
+        assertEquals("章节加载失败 — 第 3 章", got[1].message)
+        assertEquals(long, got[2].message)
+    }
+
+    // ---------------------------------------------------------------- concurrency
+
+    /**
+     * Writers from many threads while a reader loops. Two failure shapes are caught:
+     * a lost/duplicated entry (the set + size assertions), and a snapshot taken over a live
+     * collection (`ConcurrentModificationException` on the reader thread). Capacity is sized
+     * ABOVE the total so eviction cannot mask a lost write.
+     */
+    @Test
+    fun concurrentRecordLosesNothingWhileAReadIsInFlight() {
+        val threads = 8
+        val perThread = 500
+        val ring = RingBufferDiagnosticsSource(capacity = threads * perThread)
+        val start = CountDownLatch(1)
+        val stopReading = AtomicBoolean(false)
+        val readerFailure = AtomicReference<Throwable?>(null)
+        val writerFailure = AtomicReference<Throwable?>(null)
+
+        val reader = Thread {
+            start.await()
+            try {
+                while (!stopReading.get()) {
+                    runBlocking { ring.recentEntries(null, Int.MAX_VALUE) }
+                }
+            } catch (t: Throwable) {
+                readerFailure.set(t)
+            }
+        }
+        val writers = (0 until threads).map { t ->
+            Thread {
+                start.await()
+                try {
+                    repeat(perThread) { i -> ring.put("$t-$i", at = i.toLong()) }
+                } catch (e: Throwable) {
+                    writerFailure.set(e)
+                }
+            }
+        }
+
+        reader.start()
+        writers.forEach { it.start() }
+        start.countDown()
+        writers.forEach { it.join(60_000) }
+        stopReading.set(true)
+        reader.join(60_000)
+
+        assertNull("reader threw: ${readerFailure.get()}", readerFailure.get())
+        assertNull("writer threw: ${writerFailure.get()}", writerFailure.get())
+
+        val got = entries(ring)
+        val expected = (0 until threads).flatMap { t -> (0 until perThread).map { "$t-$it" } }.toSet()
+        assertEquals("lost or duplicated entries", threads * perThread, got.size)
+        assertEquals(expected, got.map { it.message }.toSet())
+    }
+
+    @Test
+    fun concurrentOverflowNeverExceedsCapacity() {
+        val ring = RingBufferDiagnosticsSource(capacity = 100)
+        val start = CountDownLatch(1)
+        val writers = (0 until 6).map { t ->
+            Thread {
+                start.await()
+                repeat(400) { i -> ring.put("$t-$i", at = i.toLong()) }
+            }
+        }
+        writers.forEach { it.start() }
+        start.countDown()
+        writers.forEach { it.join(60_000) }
+
+        assertEquals(100, entries(ring).size)
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/diagnostics/VLogTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/diagnostics/VLogTest.kt
@@ -39,7 +39,7 @@ class VLogTest {
     fun setUp() {
         ShadowLog.clear()
         ring = RingBufferDiagnosticsSource(capacity = 64)
-        VLog.install(ring) { fixedTime }
+        VLog.install(ring, clock = { fixedTime })
     }
 
     @After
@@ -85,7 +85,7 @@ class VLogTest {
     @Test
     fun installReplacesThePreviousSink() {
         val replacement = RingBufferDiagnosticsSource(capacity = 4)
-        VLog.install(replacement) { fixedTime }
+        VLog.install(replacement, clock = { fixedTime })
         VLog.w(DiagnosticsCategory.SYNC, "WebDavClient", "after swap")
 
         assertTrue(recorded().isEmpty())
@@ -198,6 +198,67 @@ class VLogTest {
         assertEquals(ringEntry.category, parsed.category)
         assertEquals(ringEntry.level, parsed.level)
         assertFalse("marker must never reach the store: ${parsed.message}", parsed.message.contains(VLogMarker.OPEN))
+    }
+
+    /**
+     * Gate-4 High regression. logd keeps entries across process launches; the ring does not. With a
+     * bare per-launch counter, launch #2's first ids would be launch #1's first ids, and the
+     * composite (ring wins a collision) would drop the prior-launch entries — precisely the
+     * pre-crash trail the platform log exists to provide.
+     */
+    @Test
+    fun idsFromTwoLaunchesNeverCollide() {
+        val firstLaunch = RingBufferDiagnosticsSource(capacity = 16)
+        VLog.install(firstLaunch, { fixedTime }, launchNonce = 1L)
+        repeat(3) { VLog.i(DiagnosticsCategory.READER, "ReaderActivity", "launch-1 #$it") }
+        val firstIds = runBlocking {
+            (firstLaunch.recentEntries(null, 10) as SourceResult.Available).entries.mapNotNull { it.sequenceId }
+        }
+
+        val secondLaunch = RingBufferDiagnosticsSource(capacity = 16)
+        VLog.install(secondLaunch, { fixedTime }, launchNonce = 2L)
+        repeat(3) { VLog.i(DiagnosticsCategory.READER, "ReaderActivity", "launch-2 #$it") }
+        val secondIds = runBlocking {
+            (secondLaunch.recentEntries(null, 10) as SourceResult.Available).entries.mapNotNull { it.sequenceId }
+        }
+
+        assertEquals(3, firstIds.size)
+        assertEquals(3, secondIds.size)
+        assertEquals(emptySet<Long>(), firstIds.toSet() intersect secondIds.toSet())
+        // Still monotonic WITHIN each launch — the nonce is fixed, only the counter moves.
+        assertEquals(firstIds.sorted(), firstIds)
+        assertEquals(secondIds.sorted(), secondIds)
+    }
+
+    /**
+     * The same defect at the composite boundary, end to end: a prior launch's entry read back from
+     * logcat must SURVIVE alongside the current launch's ring entry, even though both are "the
+     * first entry of their process".
+     */
+    @Test
+    fun aPriorLaunchLogcatEntryIsNotDroppedByTheCurrentLaunchsRing() = runBlocking {
+        val priorRing = RingBufferDiagnosticsSource(capacity = 4)
+        VLog.install(priorRing, { fixedTime }, launchNonce = 11L)
+        VLog.w(DiagnosticsCategory.READER, "ReaderActivity", "died here")
+        val priorPayload = logged().single().msg
+        val priorLine = "2026-08-04 19:26:12.114 +0000  10209  3312  3312 W Reader: $priorPayload"
+        val priorFromLogcat = LogcatLineParser.parse(sequenceOf(priorLine), ownUid = 10209)
+
+        ShadowLog.clear()
+        val currentRing = RingBufferDiagnosticsSource(capacity = 4)
+        VLog.install(currentRing, { fixedTime + 1 }, launchNonce = 12L)
+        VLog.w(DiagnosticsCategory.READER, "ReaderActivity", "fresh start")
+
+        val logcat = object : DiagnosticsLogSource {
+            override suspend fun recentEntries(sinceMillis: Long?, limit: Int) =
+                SourceResult.Available(priorFromLogcat)
+        }
+        val merged = CompositeDiagnosticsSource(logcat, currentRing).recentEntries(null, 50)
+
+        assertEquals(
+            listOf("[ReaderActivity] died here", "[ReaderActivity] fresh start"),
+            (merged as SourceResult.Available).entries.map { it.message },
+        )
     }
 
     // ---------------------------------------------------------------- uninstalled

--- a/android/app/src/test/kotlin/com/vreader/app/diagnostics/VLogTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/diagnostics/VLogTest.kt
@@ -1,0 +1,331 @@
+package com.vreader.app.diagnostics
+
+import android.util.Log
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowLog
+
+/**
+ * Feature #164 WI-3 — [VLog], the facade that records into the ring AND forwards to
+ * `android.util.Log`.
+ *
+ * Why Robolectric rather than an injectable Log seam: the plan's §10 backward-compat guarantee
+ * ("the 6 migrated sites keep emitting to android.util.Log") rests on the REAL platform call
+ * happening. A seam recording `(priority, tag, message)` would assert only that VLog called its
+ * own indirection — the identical hole the "assert on the log, not the ring" rule exists to
+ * close, one layer down. `ShadowLog` observes the genuine `android.util.Log` invocation, and
+ * Robolectric 4.13 is already a test dependency of this module.
+ *
+ * The tag change is DELIBERATE and BREAKING (plan Gate-2 M7): the logcat tag becomes the
+ * category ("Reader"), not the old per-class tag, and the class name moves into the message
+ * body ("[FoliateBridge] …"). Both halves are asserted so the break is pinned by a test rather
+ * than discovered by a developer whose `adb logcat -s FoliateBridge` went quiet.
+ */
+@RunWith(RobolectricTestRunner::class)
+class VLogTest {
+
+    private val fixedTime = 1_785_871_572_114L
+    private lateinit var ring: RingBufferDiagnosticsSource
+
+    @Before
+    fun setUp() {
+        ShadowLog.clear()
+        ring = RingBufferDiagnosticsSource(capacity = 64)
+        VLog.install(ring) { fixedTime }
+    }
+
+    @After
+    fun tearDown() {
+        VLog.uninstall()
+        ShadowLog.clear()
+    }
+
+    private fun recorded(): List<DiagnosticsLogEntry> = runBlocking {
+        (ring.recentEntries(null, Int.MAX_VALUE) as SourceResult.Available).entries
+    }
+
+    private fun logged(): List<ShadowLog.LogItem> = ShadowLog.getLogs()
+
+    // ---------------------------------------------------------------- ring side
+
+    @Test
+    fun recordsIntoTheInstalledSinkWithTheCategoryTagAsCategory() {
+        VLog.w(DiagnosticsCategory.READER, "FoliateBridge", "console[ERROR]: boom")
+
+        val entry = recorded().single()
+        assertEquals(DiagnosticsCategory.READER.tag, entry.category)
+        assertEquals("Reader", entry.category)
+        assertEquals(DiagnosticsLevel.WARN, entry.level)
+        assertEquals("[FoliateBridge] console[ERROR]: boom", entry.message)
+        assertEquals(fixedTime, entry.timeMillis)
+        assertNotNull(entry.sequenceId)
+    }
+
+    @Test
+    fun everyLevelEntryPointRecordsItsOwnLevel() {
+        VLog.d(DiagnosticsCategory.LIBRARY, "BookShare", "d")
+        VLog.i(DiagnosticsCategory.LIBRARY, "BookShare", "i")
+        VLog.w(DiagnosticsCategory.LIBRARY, "BookShare", "w")
+        VLog.e(DiagnosticsCategory.LIBRARY, "BookShare", "e")
+
+        assertEquals(
+            listOf(DiagnosticsLevel.DEBUG, DiagnosticsLevel.INFO, DiagnosticsLevel.WARN, DiagnosticsLevel.ERROR),
+            recorded().map { it.level },
+        )
+    }
+
+    @Test
+    fun installReplacesThePreviousSink() {
+        val replacement = RingBufferDiagnosticsSource(capacity = 4)
+        VLog.install(replacement) { fixedTime }
+        VLog.w(DiagnosticsCategory.SYNC, "WebDavClient", "after swap")
+
+        assertTrue(recorded().isEmpty())
+        val entry = runBlocking {
+            (replacement.recentEntries(null, Int.MAX_VALUE) as SourceResult.Available).entries.single()
+        }
+        assertEquals("[WebDavClient] after swap", entry.message)
+    }
+
+    // ---------------------------------------------------------------- LOG side (the real gate)
+
+    /**
+     * Asserted on `ShadowLog`, NOT on the ring: observing the sink proves only that the ring
+     * recorded the call. The §10 guarantee is that `android.util.Log` was invoked.
+     */
+    @Test
+    fun forwardsToAndroidLogWithThePriorityCategoryTagAndClassPrefixedBody() {
+        VLog.w(DiagnosticsCategory.READER, "FoliateBridge", "console[ERROR]: boom")
+
+        val item = logged().single()
+        assertEquals(Log.WARN, item.type)
+        assertEquals("Reader", item.tag)
+        assertTrue("body must carry the class prefix: ${item.msg}", item.msg.contains("[FoliateBridge] console[ERROR]: boom"))
+    }
+
+    @Test
+    fun theOldPerClassTagIsGoneFromTheLogItIsNowTheCategory() {
+        VLog.w(DiagnosticsCategory.READER, "FoliateBridge", "boom")
+
+        assertTrue(logged().none { it.tag == "FoliateBridge" })
+        assertEquals(listOf("Reader"), logged().map { it.tag })
+    }
+
+    @Test
+    fun everyLevelEntryPointForwardsWithTheMatchingAndroidPriority() {
+        VLog.d(DiagnosticsCategory.AI, "AnthropicProvider", "d")
+        VLog.i(DiagnosticsCategory.AI, "AnthropicProvider", "i")
+        VLog.w(DiagnosticsCategory.AI, "AnthropicProvider", "w")
+        VLog.e(DiagnosticsCategory.AI, "AnthropicProvider", "e")
+
+        assertEquals(listOf(Log.DEBUG, Log.INFO, Log.WARN, Log.ERROR), logged().map { it.type })
+        assertEquals(List(4) { "AI" }, logged().map { it.tag })
+    }
+
+    // ---------------------------------------------------------------- throwable
+
+    @Test
+    fun aThrowableAppendsItsStackTraceToBothRepresentations() {
+        val boom = IllegalStateException("kaboom")
+        VLog.w(DiagnosticsCategory.LIBRARY, "SearchIndexCoordinator", "write failed", boom)
+
+        val message = recorded().single().message
+        assertTrue(message.startsWith("[SearchIndexCoordinator] write failed"))
+        assertTrue(message.contains("java.lang.IllegalStateException: kaboom"))
+        assertTrue("stack frames must survive: $message", message.contains("\tat "))
+        // The forwarded payload carries the same trace — the two representations must agree,
+        // otherwise dedupe would surface two different-looking copies of one event.
+        assertTrue(logged().single().msg.contains("java.lang.IllegalStateException: kaboom"))
+    }
+
+    @Test
+    fun aNullThrowableAddsNothing() {
+        VLog.e(DiagnosticsCategory.SYNC, "WebDavClient", "PROPFIND 401", null)
+        assertEquals("[WebDavClient] PROPFIND 401", recorded().single().message)
+    }
+
+    // ---------------------------------------------------------------- sequence id + marker
+
+    @Test
+    fun sequenceIdsAreMonotonicAcrossCalls() {
+        repeat(5) { VLog.i(DiagnosticsCategory.LIBRARY, "BookImporter", "m$it") }
+
+        val ids = recorded().map { it.sequenceId }
+        assertTrue("no null ids expected: $ids", ids.all { it != null })
+        val values = ids.filterNotNull()
+        assertEquals(5, values.size)
+        assertEquals(values.sorted(), values)
+        assertEquals(values.distinct(), values)
+        values.zipWithNext { a, b -> assertTrue("ids must strictly increase: $values", b > a) }
+    }
+
+    @Test
+    fun theForwardedMessageCarriesTheSequenceIdAsALeadingMarker() {
+        VLog.w(DiagnosticsCategory.READER, "PdfDocument", "corrupt")
+
+        val entry = recorded().single()
+        val marker = VLogMarker.encode(entry.sequenceId!!)
+        val payload = logged().single().msg
+        assertTrue("marker must LEAD (logd truncates the tail): $payload", payload.startsWith(marker))
+        assertEquals(marker + entry.message, payload)
+    }
+
+    /**
+     * The cross-WI contract, end to end: what VLog writes to the log must parse back through
+     * WI-1's [LogcatLineParser] into an entry that identity-matches the ring's copy AND has the
+     * marker stripped. Without this, the composite's dedupe key is only asserted on each side
+     * separately and a format drift between them would go unnoticed.
+     */
+    @Test
+    fun theMarkerRoundTripsThroughTheLogcatParserAndIsStripped() {
+        VLog.w(DiagnosticsCategory.READER, "FoliateBridge", "console[ERROR]: boom @x:1")
+
+        val ringEntry = recorded().single()
+        val payload = logged().single().msg
+        val line = "2026-08-04 19:26:12.114 +0000  10209  3312  3312 W Reader: $payload"
+
+        val parsed = LogcatLineParser.parse(sequenceOf(line), ownUid = 10209).single()
+        assertEquals(ringEntry.sequenceId, parsed.sequenceId)
+        assertEquals(ringEntry.message, parsed.message)
+        assertEquals(ringEntry.category, parsed.category)
+        assertEquals(ringEntry.level, parsed.level)
+        assertFalse("marker must never reach the store: ${parsed.message}", parsed.message.contains(VLogMarker.OPEN))
+    }
+
+    // ---------------------------------------------------------------- uninstalled
+
+    @Test
+    fun callingBeforeInstallDoesNotThrowAndDoesNotRecord() {
+        VLog.uninstall()
+        val orphan = RingBufferDiagnosticsSource(capacity = 4)
+
+        VLog.w(DiagnosticsCategory.READER, "ReaderActivity", "no sink installed")
+
+        assertTrue(recorded().isEmpty())
+        assertTrue(runBlocking { (orphan.recentEntries(null, 10) as SourceResult.Available).entries }.isEmpty())
+    }
+
+    /**
+     * Deliberate: the §10 guarantee ("the migrated sites keep emitting to android.util.Log") is
+     * UNCONDITIONAL. An entry logged in the window before `VReaderApp.onCreate` installs the sink
+     * would otherwise vanish from logcat too — a silent regression against today's behavior.
+     */
+    @Test
+    fun callingBeforeInstallStillForwardsToAndroidLog() {
+        VLog.uninstall()
+
+        VLog.w(DiagnosticsCategory.READER, "ReaderActivity", "early")
+
+        val item = logged().single()
+        assertEquals(Log.WARN, item.type)
+        assertEquals("Reader", item.tag)
+        assertTrue(item.msg.contains("[ReaderActivity] early"))
+    }
+
+    // ---------------------------------------------------------------- content edge cases
+
+    @Test
+    fun emptyCjkAndLongMessagesSurviveBothRepresentations() {
+        VLog.i(DiagnosticsCategory.LIBRARY, "BookImporter", "")
+        VLog.i(DiagnosticsCategory.LIBRARY, "BookImporter", "导入失败：第 3 本书")
+        val long = "y".repeat(50_000)
+        VLog.i(DiagnosticsCategory.LIBRARY, "BookImporter", long)
+
+        val messages = recorded().map { it.message }
+        assertEquals("[BookImporter] ", messages[0])
+        assertEquals("[BookImporter] 导入失败：第 3 本书", messages[1])
+        assertEquals("[BookImporter] $long", messages[2])
+        assertEquals(3, logged().size)
+        assertTrue(logged()[1].msg.endsWith("导入失败：第 3 本书"))
+    }
+
+    @Test
+    fun anEmptyOriginStillProducesAWellFormedPrefix() {
+        VLog.w(DiagnosticsCategory.READER, "", "no origin")
+        assertEquals("[] no origin", recorded().single().message)
+    }
+}
+
+/**
+ * Feature #164 WI-3 — [DiagnosticsCategoryBounding].
+ *
+ * Lives in this file because WI-3's write-set allots exactly three test files while owning
+ * `DiagnosticsCategoryBounding.kt` (its acceptance bullet sits in WI-4, which cannot write this
+ * file). Shipping the source untested was the worse option. Pure JVM — no Robolectric needed.
+ */
+class DiagnosticsCategoryBoundingTest {
+
+    private var clock = 0L
+    private fun entry(category: String) =
+        DiagnosticsLogEntry(clock++, DiagnosticsLevel.INFO, category, "m")
+
+    private fun chipsOf(vararg categories: String) =
+        DiagnosticsCategoryBounding.chips(categories.map { entry(it) })
+
+    @Test
+    fun emptyEntriesYieldOnlyTheAllChip() {
+        assertEquals(listOf("All"), DiagnosticsCategoryBounding.chips(emptyList()))
+    }
+
+    @Test
+    fun designedCategoryTagsAreKeptVerbatim() {
+        val chips = chipsOf("Reader", "Library", "Sync")
+        assertEquals("All", chips.first())
+        assertEquals(setOf("Reader", "Library", "Sync"), chips.drop(1).toSet())
+    }
+
+    @Test
+    fun knownLibraryTagsMapOntoTheNearestDesignedCategory() {
+        assertTrue(chipsOf("SQLiteLog").contains(DiagnosticsCategory.PERSISTENCE.tag))
+        assertTrue(chipsOf("chromium").contains(DiagnosticsCategory.READER.tag))
+        assertTrue(chipsOf("cr_MediaCodecBridge").contains(DiagnosticsCategory.READER.tag))
+        assertTrue(chipsOf("OkHttp").contains(DiagnosticsCategory.SYNC.tag))
+    }
+
+    @Test
+    fun unknownTagsCollapseIntoTheSingleBucket() {
+        val chips = chipsOf("ActivityManager", "ziparchive", "libEGL")
+        assertEquals(listOf("All", DiagnosticsCategoryBounding.COLLAPSED_BUCKET), chips)
+    }
+
+    @Test
+    fun anEmptyCategoryIsIgnoredEntirely() {
+        assertEquals(listOf("All"), chipsOf("", "  "))
+    }
+
+    @Test
+    fun theChipRowIsHardCappedEvenWithFortyDistinctRawTags() {
+        val many = (1..40).map { entry("RandomFrameworkTag$it") } +
+            DiagnosticsCategory.entries.map { entry(it.tag) }
+        val chips = DiagnosticsCategoryBounding.chips(many)
+
+        assertEquals("All", chips.first())
+        assertTrue("at most the designed 7 category chips, got ${chips.size - 1}", chips.size - 1 <= 7)
+        assertEquals(chips.distinct(), chips)
+    }
+
+    @Test
+    fun chipsAreRankedByEntryCountDescending() {
+        val entries = List(5) { entry("Sync") } + List(3) { entry("Reader") } + List(1) { entry("AI") }
+        assertEquals(listOf("All", "Sync", "Reader", "AI"), DiagnosticsCategoryBounding.chips(entries))
+    }
+
+    @Test
+    fun aCollapsedTagIsStillReachableByFilteringOnTheBucket() {
+        val entries = listOf(entry("ziparchive"), entry("Reader"))
+        assertTrue(DiagnosticsCategoryBounding.chips(entries).contains(DiagnosticsCategoryBounding.COLLAPSED_BUCKET))
+        assertEquals(
+            listOf("ziparchive"),
+            entries.filter { DiagnosticsCategoryBounding.chipFor(it.category) == DiagnosticsCategoryBounding.COLLAPSED_BUCKET }
+                .map { it.category },
+        )
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/diagnostics/VLogTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/diagnostics/VLogTest.kt
@@ -205,9 +205,13 @@ class VLogTest {
      * bare per-launch counter, launch #2's first ids would be launch #1's first ids, and the
      * composite (ring wins a collision) would drop the prior-launch entries — precisely the
      * pre-crash trail the platform log exists to provide.
+     *
+     * The name says DISTINCT nonces, not "never": production draws the nonce at random, so the
+     * guarantee is probabilistic (~1 in 2^21 per launch pair), and overclaiming it in a test name
+     * would misrepresent what is actually asserted.
      */
     @Test
-    fun idsFromTwoLaunchesNeverCollide() {
+    fun idsFromTwoLaunchesWithDistinctNoncesDoNotCollide() {
         val firstLaunch = RingBufferDiagnosticsSource(capacity = 16)
         VLog.install(firstLaunch, { fixedTime }, launchNonce = 1L)
         repeat(3) { VLog.i(DiagnosticsCategory.READER, "ReaderActivity", "launch-1 #$it") }
@@ -357,9 +361,14 @@ class DiagnosticsCategoryBoundingTest {
         assertEquals(listOf("All", DiagnosticsCategoryBounding.COLLAPSED_BUCKET), chips)
     }
 
+    /**
+     * A tagless logcat line parses to `category == ""`. It must be FILTERABLE (via the bucket), not
+     * silently reachable only under `All`.
+     */
     @Test
-    fun anEmptyCategoryIsIgnoredEntirely() {
-        assertEquals(listOf("All"), chipsOf("", "  "))
+    fun aBlankCategoryIsBucketedNotDropped() {
+        assertEquals(listOf("All", DiagnosticsCategoryBounding.COLLAPSED_BUCKET), chipsOf("", "  "))
+        assertEquals(DiagnosticsCategoryBounding.COLLAPSED_BUCKET, DiagnosticsCategoryBounding.chipFor(""))
     }
 
     @Test

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.20.26
-versionCode=179
+versionName=0.20.27
+versionCode=180

--- a/scripts/__tests__/check-android-log-containment.sh
+++ b/scripts/__tests__/check-android-log-containment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Feature #164 WI-3 — the `android.util.Log` containment gate.
 #
-# Contract: NO production Kotlin source under android/app/src/main may reference
+# Contract: NO shipped production source under android/app/src may reference
 # `android.util.Log`, except the one file that owns the forward — `VLog.kt`. That
 # single choke point is what makes "every log entry is captured, categorised and
 # redactable" true by construction instead of by convention.
@@ -10,32 +10,44 @@
 # not a gate, because nothing runs it. The 6 sites migrated in WI-3 would drift back
 # the first time someone reached for the familiar API.
 #
-# Why it matches TWO shapes: 4 of the 6 pre-migration sites used the SHORT form
-# (`Log.w(TAG, …)` + `import android.util.Log`) and only 2 used the qualified
-# `android.util.Log.w(…)`. A qualified-only check would have passed while missing
-# most of what it exists to catch.
+# WHAT IT MATCHES, and why it is a BAN ON THE NAME rather than on call shapes
+# (Gate-4 Medium): the first version keyed on the two shapes present in the tree —
+# qualified `android.util.Log.w(…)` and short `Log.w(…)` behind a plain import — and
+# the auditor produced four one-line evasions: `import android.util.Log as Platform`,
+# `import android.util.*`, a qualified call split across lines, and the same inside a
+# string template. So the rule is now simply: the literal `android.util.Log` may not
+# appear in code, and `import android.util.*` (which pulls Log into scope) is banned
+# too. Every listed evasion contains one of those two, including the multi-line split
+# (the qualified prefix still sits on one line) and the reflective
+# `Class.forName("android.util.Log")`.
 #
 # Comments are stripped before matching — WI-1/WI-2's KDoc, and this project's own
 # convention of explaining decisions in headers, legitimately name the API in prose.
 #
+# SCOPE: every source set under android/app/src EXCEPT test / androidTest / debug —
+# `.kt` AND `.java`, so a Java file or a future `src/release` flavor cannot slip past.
+# The three exclusions are not shipped in the release APK; a debug-only launcher
+# logging directly is out of this contract's scope.
+#
 # Run:
 #   bash scripts/__tests__/check-android-log-containment.sh          # self-test + real tree
-#   bash scripts/__tests__/check-android-log-containment.sh --scan <src-dir> [<allow-regex>]
+#   bash scripts/__tests__/check-android-log-containment.sh --scan <src-dir> [<allow-regex>] [<exclude-regex>]
 
 set -uo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$HERE/../.." && pwd)"
 
-DEFAULT_SRC="$ROOT/android/app/src/main/kotlin"
+DEFAULT_SRC="$ROOT/android/app/src"
 DEFAULT_ALLOW='/diagnostics/VLog\.kt$'
+DEFAULT_EXCLUDE='/src/(test|androidTest|debug)/'
 
-# The 6 migrated sites: "<file under android/app/src/main/kotlin>|<expected VLog origin>".
+# The 6 migrated sites: "<file under android/app/src>|<expected VLog origin>".
 MIGRATED_SITES=(
-    "com/vreader/app/reader/PdfDocument.kt|PdfDocument"
-    "com/vreader/app/reader/ReaderActivity.kt|ReaderActivity"
-    "com/vreader/app/reader/foliate/FoliateBridge.kt|FoliateBridge"
-    "com/vreader/app/reader/share/BookShareIntent.kt|BookShare"
-    "com/vreader/app/search/SearchIndexCoordinator.kt|SearchIndexCoordinator"
+    "main/kotlin/com/vreader/app/reader/PdfDocument.kt|PdfDocument"
+    "main/kotlin/com/vreader/app/reader/ReaderActivity.kt|ReaderActivity"
+    "main/kotlin/com/vreader/app/reader/foliate/FoliateBridge.kt|FoliateBridge"
+    "main/kotlin/com/vreader/app/reader/share/BookShareIntent.kt|BookShare"
+    "main/kotlin/com/vreader/app/search/SearchIndexCoordinator.kt|SearchIndexCoordinator"
 )
 EXPECTED_VLOG_CALLS=6
 
@@ -44,7 +56,7 @@ EXPECTED_VLOG_CALLS=6
 # Print "file:line: text" for every offending reference in <src-dir>.
 # Exit 0 = clean, 1 = findings, 2 = error.
 scan() {
-    local src="$1" allow="${2:-$DEFAULT_ALLOW}"
+    local src="$1" allow="${2:-$DEFAULT_ALLOW}" exclude="${3:-$DEFAULT_EXCLUDE}"
     if [ ! -d "$src" ]; then
         echo "CHECK-ANDROID-LOG-CONTAINMENT RESULT: ERROR (no such source tree: $src)"
         return 2
@@ -52,6 +64,7 @@ scan() {
 
     local findings=0 file
     while IFS= read -r file; do
+        [ -n "$exclude" ] && [[ "$file" =~ $exclude ]] && continue
         [[ "$file" =~ $allow ]] && continue
         local out
         out="$(awk -v f="$file" '
@@ -60,11 +73,12 @@ scan() {
             {
                 line = $0
                 sub(/\/\/.*/, "", line)                       # strip a trailing line comment
-                if (line ~ /android\.util\.Log\./) {
-                    printf "%s:%d: %s\n", f, NR, $0; next
-                }
-                if (line ~ /^import[[:space:]]+android\.util\.Log[[:space:]]*$/) { imported = 1; next }
-                if (imported && line ~ /(^|[^A-Za-z0-9_.$])Log\.(v|d|i|w|e|wtf|println|isLoggable)[[:space:]]*\(/) {
+                # The NAME itself is banned — that covers the plain import, an aliased import,
+                # a qualified call (even split across lines: the prefix stays on one line), and
+                # a reflective Class.forName("android.util.Log").
+                if (line ~ /android\.util\.Log/) { printf "%s:%d: %s\n", f, NR, $0; next }
+                # A wildcard import pulls Log into scope without ever naming it.
+                if (line ~ /^[[:space:]]*import[[:space:]]+android\.util\.\*/) {
                     printf "%s:%d: %s\n", f, NR, $0
                 }
             }
@@ -73,7 +87,7 @@ scan() {
             printf '%s\n' "$out"
             findings=$((findings + 1))
         fi
-    done < <(find "$src" -name '*.kt' -type f | sort)
+    done < <(find "$src" \( -name '*.kt' -o -name '*.java' \) -type f | sort)
 
     if [ "$findings" -eq 0 ]; then
         echo "CHECK-ANDROID-LOG-CONTAINMENT RESULT: OK (0 files)"
@@ -85,7 +99,7 @@ scan() {
 
 if [ "${1:-}" = "--scan" ]; then
     shift
-    scan "${1:?--scan needs a source dir}" "${2:-$DEFAULT_ALLOW}"
+    scan "${1:?--scan needs a source dir}" "${2:-$DEFAULT_ALLOW}" "${3:-$DEFAULT_EXCLUDE}"
     exit $?
 fi
 
@@ -99,8 +113,9 @@ echo "== check-android-log-containment =="
 
 FIX="$(mktemp -d -t log-containment.XXXXXX)"
 trap 'rm -rf "$FIX"' EXIT
-SRC="$FIX/kotlin/com/vreader/app"
-mkdir -p "$SRC/diagnostics" "$SRC/reader"
+SRC="$FIX/src/main/kotlin/com/vreader/app"
+mkdir -p "$SRC/diagnostics" "$SRC/reader" "$FIX/src/main/java/com/vreader/app" \
+         "$FIX/src/test/kotlin" "$FIX/src/androidTest/kotlin" "$FIX/src/debug/kotlin"
 
 # 1. qualified form — must be flagged.
 cat > "$SRC/reader/Qualified.kt" <<'KOTLIN'
@@ -148,7 +163,49 @@ import com.example.telemetry.Log
 class OtherLog { fun go() = Log.w("t", "not the android one") }
 KOTLIN
 
-OUT="$("$0" --scan "$FIX/kotlin")"; RC=$?
+# 6-9. The four evasions the Gate-4 audit produced against the first (shape-keyed) version.
+cat > "$SRC/reader/Aliased.kt" <<'KOTLIN'
+package com.vreader.app.reader
+import android.util.Log as PlatformLog
+class Aliased { fun go() = PlatformLog.w("Reader", "escaped") }
+KOTLIN
+
+cat > "$SRC/reader/Wildcard.kt" <<'KOTLIN'
+package com.vreader.app.reader
+import android.util.*
+class Wildcard { fun go() = Log.w("Reader", "escaped") }
+KOTLIN
+
+cat > "$SRC/reader/SplitCall.kt" <<'KOTLIN'
+package com.vreader.app.reader
+class SplitCall {
+    fun go() = android.util.Log
+        .w("Reader", "escaped")
+}
+KOTLIN
+
+cat > "$SRC/reader/Reflective.kt" <<'KOTLIN'
+package com.vreader.app.reader
+class Reflective { fun go() = Class.forName("android.util.Log") }
+KOTLIN
+
+# 10. a JAVA production file — the source set is shipped, so it must be scanned.
+cat > "$FIX/src/main/java/com/vreader/app/LegacyBridge.java" <<'JAVA'
+package com.vreader.app;
+import android.util.Log;
+public class LegacyBridge { void go() { Log.w("Reader", "escaped"); } }
+JAVA
+
+# 11-13. NON-shipped source sets — must be skipped by the exclude rule.
+for set in test androidTest debug; do
+    cat > "$FIX/src/$set/kotlin/Harness.kt" <<'KOTLIN'
+package com.vreader.app
+import android.util.Log
+class Harness { fun go() = Log.w("t", "allowed here") }
+KOTLIN
+done
+
+OUT="$("$0" --scan "$FIX/src")"; RC=$?
 
 # Assertions are anchored on the "<file>:<line>:" FINDING form, never a bare filename —
 # the RESULT summary line itself names VLog.kt, which a loose grep happily matches.
@@ -156,8 +213,10 @@ grep -q "Qualified\.kt:3:" <<<"$OUT" \
     && ok "qualified android.util.Log.w flagged" \
     || fail "qualified form NOT flagged"
 
-grep -q "Short\.kt:5:" <<<"$OUT" \
-    && ok "short-form Log.w + import flagged (the 4-of-6 case)" \
+# The 4-of-6 case. Reported at the IMPORT line, not the call: banning the name is what
+# makes the aliased and wildcard variants below fall out for free.
+grep -q "Short\.kt:2:" <<<"$OUT" \
+    && ok "short-form Log.w + import flagged at its import (the 4-of-6 case)" \
     || fail "short form NOT flagged — a qualified-only check would ship"
 
 grep -q "Prose\.kt:[0-9]" <<<"$OUT" \
@@ -171,6 +230,20 @@ grep -q "VLog\.kt:[0-9]" <<<"$OUT" \
 grep -q "OtherLog\.kt:[0-9]" <<<"$OUT" \
     && fail "a non-android Log type was flagged" \
     || ok "short form without the android import ignored"
+
+# The four evasions the audit named, plus the Java source set.
+for evasion in Aliased Wildcard SplitCall Reflective; do
+    grep -q "$evasion\.kt:[0-9]" <<<"$OUT" \
+        && ok "evasion caught: $evasion" \
+        || fail "EVASION NOT CAUGHT: $evasion"
+done
+grep -q "LegacyBridge\.java:[0-9]" <<<"$OUT" \
+    && ok "shipped .java source is scanned" \
+    || fail "a Java production file evaded the gate"
+
+grep -q "Harness\.kt:[0-9]" <<<"$OUT" \
+    && fail "a non-shipped source set (test/androidTest/debug) was flagged" \
+    || ok "test / androidTest / debug source sets excluded"
 
 [ "$RC" -eq 1 ] \
     && ok "exit 1 on findings" \

--- a/scripts/__tests__/check-android-log-containment.sh
+++ b/scripts/__tests__/check-android-log-containment.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Feature #164 WI-3 — the `android.util.Log` containment gate.
+#
+# Contract: NO production Kotlin source under android/app/src/main may reference
+# `android.util.Log`, except the one file that owns the forward — `VLog.kt`. That
+# single choke point is what makes "every log entry is captured, categorised and
+# redactable" true by construction instead of by convention.
+#
+# Why this is a SCRIPT and not an acceptance bullet: a grep written into a plan is
+# not a gate, because nothing runs it. The 6 sites migrated in WI-3 would drift back
+# the first time someone reached for the familiar API.
+#
+# Why it matches TWO shapes: 4 of the 6 pre-migration sites used the SHORT form
+# (`Log.w(TAG, …)` + `import android.util.Log`) and only 2 used the qualified
+# `android.util.Log.w(…)`. A qualified-only check would have passed while missing
+# most of what it exists to catch.
+#
+# Comments are stripped before matching — WI-1/WI-2's KDoc, and this project's own
+# convention of explaining decisions in headers, legitimately name the API in prose.
+#
+# Run:
+#   bash scripts/__tests__/check-android-log-containment.sh          # self-test + real tree
+#   bash scripts/__tests__/check-android-log-containment.sh --scan <src-dir> [<allow-regex>]
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+DEFAULT_SRC="$ROOT/android/app/src/main/kotlin"
+DEFAULT_ALLOW='/diagnostics/VLog\.kt$'
+
+# The 6 migrated sites: "<file under android/app/src/main/kotlin>|<expected VLog origin>".
+MIGRATED_SITES=(
+    "com/vreader/app/reader/PdfDocument.kt|PdfDocument"
+    "com/vreader/app/reader/ReaderActivity.kt|ReaderActivity"
+    "com/vreader/app/reader/foliate/FoliateBridge.kt|FoliateBridge"
+    "com/vreader/app/reader/share/BookShareIntent.kt|BookShare"
+    "com/vreader/app/search/SearchIndexCoordinator.kt|SearchIndexCoordinator"
+)
+EXPECTED_VLOG_CALLS=6
+
+# ---------------------------------------------------------------- the scan
+
+# Print "file:line: text" for every offending reference in <src-dir>.
+# Exit 0 = clean, 1 = findings, 2 = error.
+scan() {
+    local src="$1" allow="${2:-$DEFAULT_ALLOW}"
+    if [ ! -d "$src" ]; then
+        echo "CHECK-ANDROID-LOG-CONTAINMENT RESULT: ERROR (no such source tree: $src)"
+        return 2
+    fi
+
+    local findings=0 file
+    while IFS= read -r file; do
+        [[ "$file" =~ $allow ]] && continue
+        local out
+        out="$(awk -v f="$file" '
+            # A full-line block-comment body (" * …", "/* …", "/** …") is prose, never code.
+            /^[[:space:]]*(\*|\/\*)/ { next }
+            {
+                line = $0
+                sub(/\/\/.*/, "", line)                       # strip a trailing line comment
+                if (line ~ /android\.util\.Log\./) {
+                    printf "%s:%d: %s\n", f, NR, $0; next
+                }
+                if (line ~ /^import[[:space:]]+android\.util\.Log[[:space:]]*$/) { imported = 1; next }
+                if (imported && line ~ /(^|[^A-Za-z0-9_.$])Log\.(v|d|i|w|e|wtf|println|isLoggable)[[:space:]]*\(/) {
+                    printf "%s:%d: %s\n", f, NR, $0
+                }
+            }
+        ' "$file")"
+        if [ -n "$out" ]; then
+            printf '%s\n' "$out"
+            findings=$((findings + 1))
+        fi
+    done < <(find "$src" -name '*.kt' -type f | sort)
+
+    if [ "$findings" -eq 0 ]; then
+        echo "CHECK-ANDROID-LOG-CONTAINMENT RESULT: OK (0 files)"
+        return 0
+    fi
+    echo "CHECK-ANDROID-LOG-CONTAINMENT RESULT: FINDINGS ($findings file(s) outside VLog.kt)"
+    return 1
+}
+
+if [ "${1:-}" = "--scan" ]; then
+    shift
+    scan "${1:?--scan needs a source dir}" "${2:-$DEFAULT_ALLOW}"
+    exit $?
+fi
+
+# ---------------------------------------------------------------- self-test
+
+fails=0
+ok()   { echo "ok   — $1"; }
+fail() { echo "FAIL — $1"; fails=$((fails + 1)); }
+
+echo "== check-android-log-containment =="
+
+FIX="$(mktemp -d -t log-containment.XXXXXX)"
+trap 'rm -rf "$FIX"' EXIT
+SRC="$FIX/kotlin/com/vreader/app"
+mkdir -p "$SRC/diagnostics" "$SRC/reader"
+
+# 1. qualified form — must be flagged.
+cat > "$SRC/reader/Qualified.kt" <<'KOTLIN'
+package com.vreader.app.reader
+class Qualified {
+    fun boom() = android.util.Log.w("Qualified", "nope")
+}
+KOTLIN
+
+# 2. SHORT form + import — must be flagged (the form 4 of the 6 real sites used).
+cat > "$SRC/reader/Short.kt" <<'KOTLIN'
+package com.vreader.app.reader
+import android.util.Log
+private const val TAG = "Short"
+class Short {
+    fun boom() = Log.w(TAG, "nope")
+}
+KOTLIN
+
+# 3. prose only — must NOT be flagged (WI-1/WI-2 headers do exactly this).
+cat > "$SRC/reader/Prose.kt" <<'KOTLIN'
+package com.vreader.app.reader
+/**
+ * Mirrors android.util.Log's priority set; see android.util.Log.w for the shape.
+ */
+class Prose {
+    // android.util.Log.w(TAG, "commented out") — kept for context
+    fun fine() = Unit
+}
+KOTLIN
+
+# 4. the allowed owner — must NOT be flagged even using both forms.
+cat > "$SRC/diagnostics/VLog.kt" <<'KOTLIN'
+package com.vreader.app.diagnostics
+import android.util.Log
+object VLog {
+    fun w(tag: String, m: String) { Log.w(tag, m); android.util.Log.i(tag, m) }
+}
+KOTLIN
+
+# 5. an unrelated `Log` type with NO android import — must NOT be flagged.
+cat > "$SRC/reader/OtherLog.kt" <<'KOTLIN'
+package com.vreader.app.reader
+import com.example.telemetry.Log
+class OtherLog { fun go() = Log.w("t", "not the android one") }
+KOTLIN
+
+OUT="$("$0" --scan "$FIX/kotlin")"; RC=$?
+
+# Assertions are anchored on the "<file>:<line>:" FINDING form, never a bare filename —
+# the RESULT summary line itself names VLog.kt, which a loose grep happily matches.
+grep -q "Qualified\.kt:3:" <<<"$OUT" \
+    && ok "qualified android.util.Log.w flagged" \
+    || fail "qualified form NOT flagged"
+
+grep -q "Short\.kt:5:" <<<"$OUT" \
+    && ok "short-form Log.w + import flagged (the 4-of-6 case)" \
+    || fail "short form NOT flagged — a qualified-only check would ship"
+
+grep -q "Prose\.kt:[0-9]" <<<"$OUT" \
+    && fail "KDoc/comment mention was flagged (false positive)" \
+    || ok "comment-only mentions ignored"
+
+grep -q "VLog\.kt:[0-9]" <<<"$OUT" \
+    && fail "the allowed owner VLog.kt was flagged" \
+    || ok "VLog.kt exempted"
+
+grep -q "OtherLog\.kt:[0-9]" <<<"$OUT" \
+    && fail "a non-android Log type was flagged" \
+    || ok "short form without the android import ignored"
+
+[ "$RC" -eq 1 ] \
+    && ok "exit 1 on findings" \
+    || fail "expected exit 1 on findings, got $RC"
+
+CLEAN_DIR="$FIX/clean"; mkdir -p "$CLEAN_DIR"
+cp "$SRC/reader/Prose.kt" "$CLEAN_DIR/"
+CLEAN="$("$0" --scan "$CLEAN_DIR")"; CRC=$?
+if [ "$CRC" -eq 0 ] && [ "$(tail -1 <<<"$CLEAN")" = "CHECK-ANDROID-LOG-CONTAINMENT RESULT: OK (0 files)" ]; then
+    ok "clean tree exits 0 with RESULT: OK"
+else
+    fail "clean run wrong (rc=$CRC last='$(tail -1 <<<"$CLEAN")')"
+fi
+
+MISSING="$("$0" --scan "$FIX/nope")"; MRC=$?
+if [ "$MRC" -eq 2 ] && grep -q "RESULT: ERROR" <<<"$MISSING"; then
+    ok "missing source tree exits 2 with RESULT: ERROR"
+else
+    fail "missing source tree mishandled (rc=$MRC)"
+fi
+
+# ---------------------------------------------------------------- the real tree
+
+echo
+echo "-- real tree: $DEFAULT_SRC"
+REAL="$(scan "$DEFAULT_SRC")"; RRC=$?
+printf '%s\n' "$REAL"
+[ "$RRC" -eq 0 ] \
+    && ok "android/app/src/main is clean of android.util.Log outside VLog.kt" \
+    || fail "production sources still reference android.util.Log"
+
+# The other half of the migration: every one of the 6 sites must ROUTE through VLog.
+total_calls=0
+for site in "${MIGRATED_SITES[@]}"; do
+    rel="${site%%|*}"; origin="${site##*|}"
+    path="$DEFAULT_SRC/$rel"
+    if [ ! -f "$path" ]; then fail "migrated site missing: $rel"; continue; fi
+    n="$(grep -c 'VLog\.[wide](' "$path")"
+    total_calls=$((total_calls + n))
+    if [ "$n" -ge 1 ] && grep -q "\"$origin\"\|TAG" "$path"; then
+        ok "$rel routes through VLog ($n call(s), origin \"$origin\")"
+    else
+        fail "$rel does not route through VLog with origin \"$origin\""
+    fi
+done
+[ "$total_calls" -eq "$EXPECTED_VLOG_CALLS" ] \
+    && ok "all $EXPECTED_VLOG_CALLS migrated call sites accounted for" \
+    || fail "expected $EXPECTED_VLOG_CALLS VLog calls across the migrated files, found $total_calls"
+
+echo
+if [ "$fails" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$fails FAILURE(S)"; exit 1; fi

--- a/scripts/__tests__/check-android-log-containment.sh
+++ b/scripts/__tests__/check-android-log-containment.sh
@@ -70,7 +70,7 @@ EXPECTED_VLOG_CALLS=6
 # Print "file:line: text" for every offending reference in <src-dir>.
 # Exit 0 = clean, 1 = findings, 2 = error.
 scan() {
-    local src="$1" allow="${2:-$DEFAULT_ALLOW}"
+    local src="${1%/}" allow="${2:-$DEFAULT_ALLOW}"   # a trailing slash would break the prefix strip
     if [ ! -d "$src" ]; then
         echo "CHECK-ANDROID-LOG-CONTAINMENT RESULT: ERROR (no such source tree: $src)"
         return 2
@@ -85,12 +85,23 @@ scan() {
         out="$(awk -v f="$file" '
             # Remove comments with a state machine, so neither a block comment sharing a line
             # with code nor a "//" inside a string literal can hide a reference.
+            # inBlock and inRaw persist ACROSS lines (awk runs once per file, so they reset per
+            # file, which is what we want). inStr and esc are per-line: an unterminated ordinary
+            # string is a syntax error, and resetting keeps one odd line from poisoning the rest.
+            # String CONTENT is kept in the output on purpose — that is what catches
+            # Class.forName("android.util.Log"). Only the comment-introducing role of // and /*
+            # is suppressed inside a string.
             function strip(l,   out, i, c, n, inStr, esc) {
                 out = ""; n = length(l); i = 1
                 while (i <= n) {
                     c = substr(l, i, 1)
                     if (inBlock) {                                  # inside /* … */
                         if (substr(l, i, 2) == "*/") { inBlock = 0; i += 2 } else { i++ }
+                        continue
+                    }
+                    if (inRaw) {                                    # inside a """ raw string """
+                        if (substr(l, i, 3) == "\"\"\"") { inRaw = 0; out = out "\"\"\""; i += 3 }
+                        else { out = out c; i++ }
                         continue
                     }
                     if (inStr) {
@@ -101,8 +112,18 @@ scan() {
                         i++
                         continue
                     }
+                    if (substr(l, i, 3) == "\"\"\"") { inRaw = 1; out = out "\"\"\""; i += 3; continue }
                     if (substr(l, i, 2) == "/*") { inBlock = 1; i += 2; continue }
                     if (substr(l, i, 2) == "//") { break }          # rest of the line is a comment
+                    if (c == "\x27") {                              # char literal, e.g. the quote char
+                        out = out c; i++
+                        while (i <= n) {
+                            c = substr(l, i, 1); out = out c; i++
+                            if (c == "\\") { if (i <= n) { out = out substr(l, i, 1); i++ } }
+                            else if (c == "\x27") { break }
+                        }
+                        continue
+                    }
                     if (c == "\"") { inStr = 1 }
                     out = out c
                     i++
@@ -281,6 +302,25 @@ import android.util.Log
 class Generated { fun go() = Log.w("t", "generated") }
 KOTLIN
 
+# 20. RAW STRING evasion (round 3): a """ … """ containing a lone quote and a // used to leave the
+# machine mid-string, so the // on the NEXT construct read as a comment and hid the reference.
+cat > "$SRC/reader/RawString.kt" <<'KOTLIN'
+package com.vreader.app.reader
+class RawString {
+    val harmless = """ " // raw text """
+    fun go() = android.util.Log.w("Reader", "escaped")
+}
+KOTLIN
+
+# 21. CHAR LITERAL holding a double quote — must not put the machine into string state.
+cat > "$SRC/reader/CharLiteral.kt" <<'KOTLIN'
+package com.vreader.app.reader
+class CharLiteral {
+    val quote = '"'
+    fun go() = android.util.Log.w("Reader", "escaped")
+}
+KOTLIN
+
 # 19. a MULTI-LINE block comment whose body has no leading '*' — prose, must NOT be flagged.
 cat > "$SRC/reader/LooseBlockProse.kt" <<'KOTLIN'
 package com.vreader.app.reader
@@ -317,7 +357,7 @@ grep -q "OtherLog\.kt:[0-9]" <<<"$OUT" \
     || ok "short form without the android import ignored"
 
 # Every evasion the two audit rounds named.
-for evasion in Aliased Wildcard SplitCall Reflective InlineBlock SlashInString Sneaky; do
+for evasion in Aliased Wildcard SplitCall Reflective InlineBlock SlashInString Sneaky RawString CharLiteral; do
     grep -q "$evasion\.kt:[0-9]" <<<"$OUT" \
         && ok "evasion caught: $evasion" \
         || fail "EVASION NOT CAUGHT: $evasion"
@@ -353,6 +393,14 @@ if [ "$CRC" -eq 0 ] && [ "$(tail -1 <<<"$CLEAN")" = "CHECK-ANDROID-LOG-CONTAINME
     ok "clean tree exits 0 with RESULT: OK"
 else
     fail "clean run wrong (rc=$CRC last='$(tail -1 <<<"$CLEAN")')"
+fi
+
+# A trailing slash on the scan root must not break the relative-path exclusion.
+SLASHED="$("$0" --scan "$FIX/")"
+if [ "$(grep -c ':' <<<"$SLASHED")" = "$(grep -c ':' <<<"$OUT")" ]; then
+    ok "trailing slash on the scan root gives identical results"
+else
+    fail "trailing slash changed the finding set"
 fi
 
 MISSING="$("$0" --scan "$FIX/nope")"; MRC=$?

--- a/scripts/__tests__/check-android-log-containment.sh
+++ b/scripts/__tests__/check-android-log-containment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Feature #164 WI-3 — the `android.util.Log` containment gate.
 #
-# Contract: NO shipped production source under android/app/src may reference
+# Contract: NO shipped production source anywhere under android/ may reference
 # `android.util.Log`, except the one file that owns the forward — `VLog.kt`. That
 # single choke point is what makes "every log entry is captured, categorised and
 # redactable" true by construction instead of by convention.
@@ -21,33 +21,47 @@
 # (the qualified prefix still sits on one line) and the reflective
 # `Class.forName("android.util.Log")`.
 #
-# Comments are stripped before matching — WI-1/WI-2's KDoc, and this project's own
-# convention of explaining decisions in headers, legitimately name the API in prose.
+# COMMENTS AND STRINGS (Gate-4 round 2): stripping is done by a small state machine,
+# not by two line regexes. The naive version skipped any line STARTING with `/*` —
+# so `/** doc */ val p = android.util.Log.WARN` was skipped wholesale — and cut every
+# line at its first `//`, so `"https://x".length + android.util.Log.WARN` was cut
+# inside a string literal. The machine tracks multi-line block comments across lines,
+# removes complete inline `/* … */` spans, and honours `//` only OUTSIDE a double-
+# quoted string. Prose (WI-1/WI-2's KDoc, this project's decision headers) still does
+# not trip the gate.
 #
-# SCOPE: every source set under android/app/src EXCEPT test / androidTest / debug —
-# `.kt` AND `.java`, so a Java file or a future `src/release` flavor cannot slip past.
-# The three exclusions are not shipped in the release APK; a debug-only launcher
-# logging directly is out of this contract's scope.
+# ACCEPTED LIMITATION: a name assembled at runtime — `Class.forName("android." +
+# "util.Log")` — is invisible to any textual gate. This gate stops accidental drift
+# and honest reintroduction; it is not an adversarial sandbox. Catching that would
+# need bytecode/dependency analysis, which is out of scope for WI-3.
+#
+# SCOPE: every source set under android/ EXCEPT test / androidTest / debug (matched as
+# the source-set segment directly beneath a module, not as a loose substring), and
+# excluding generated `build/` output. `.kt` AND `.java`, so a Java file, a future
+# `src/release` flavor, or another Gradle module (`:identity`) cannot slip past. The
+# three exclusions are not shipped in the release APK; a debug-only launcher logging
+# directly is out of this contract's scope.
 #
 # Run:
 #   bash scripts/__tests__/check-android-log-containment.sh          # self-test + real tree
-#   bash scripts/__tests__/check-android-log-containment.sh --scan <src-dir> [<allow-regex>] [<exclude-regex>]
+#   bash scripts/__tests__/check-android-log-containment.sh --scan <root> [<allow-regex>]
 
 set -uo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$HERE/../.." && pwd)"
 
-DEFAULT_SRC="$ROOT/android/app/src"
+DEFAULT_SRC="$ROOT/android"
 DEFAULT_ALLOW='/diagnostics/VLog\.kt$'
-DEFAULT_EXCLUDE='/src/(test|androidTest|debug)/'
+# Applied to the path RELATIVE to the scan root: "<module>/src/<set>/…".
+NON_SHIPPED_SET='^[^/]+/src/(test|androidTest|debug)/'
 
-# The 6 migrated sites: "<file under android/app/src>|<expected VLog origin>".
+# The 6 migrated sites: "<file under android/>|<expected VLog origin>".
 MIGRATED_SITES=(
-    "main/kotlin/com/vreader/app/reader/PdfDocument.kt|PdfDocument"
-    "main/kotlin/com/vreader/app/reader/ReaderActivity.kt|ReaderActivity"
-    "main/kotlin/com/vreader/app/reader/foliate/FoliateBridge.kt|FoliateBridge"
-    "main/kotlin/com/vreader/app/reader/share/BookShareIntent.kt|BookShare"
-    "main/kotlin/com/vreader/app/search/SearchIndexCoordinator.kt|SearchIndexCoordinator"
+    "app/src/main/kotlin/com/vreader/app/reader/PdfDocument.kt|PdfDocument"
+    "app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt|ReaderActivity"
+    "app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateBridge.kt|FoliateBridge"
+    "app/src/main/kotlin/com/vreader/app/reader/share/BookShareIntent.kt|BookShare"
+    "app/src/main/kotlin/com/vreader/app/search/SearchIndexCoordinator.kt|SearchIndexCoordinator"
 )
 EXPECTED_VLOG_CALLS=6
 
@@ -56,23 +70,47 @@ EXPECTED_VLOG_CALLS=6
 # Print "file:line: text" for every offending reference in <src-dir>.
 # Exit 0 = clean, 1 = findings, 2 = error.
 scan() {
-    local src="$1" allow="${2:-$DEFAULT_ALLOW}" exclude="${3:-$DEFAULT_EXCLUDE}"
+    local src="$1" allow="${2:-$DEFAULT_ALLOW}"
     if [ ! -d "$src" ]; then
         echo "CHECK-ANDROID-LOG-CONTAINMENT RESULT: ERROR (no such source tree: $src)"
         return 2
     fi
 
-    local findings=0 file
+    local findings=0 file rel
     while IFS= read -r file; do
-        [ -n "$exclude" ] && [[ "$file" =~ $exclude ]] && continue
+        rel="${file#"$src"/}"
+        [[ "$rel" =~ $NON_SHIPPED_SET ]] && continue
         [[ "$file" =~ $allow ]] && continue
         local out
         out="$(awk -v f="$file" '
-            # A full-line block-comment body (" * …", "/* …", "/** …") is prose, never code.
-            /^[[:space:]]*(\*|\/\*)/ { next }
+            # Remove comments with a state machine, so neither a block comment sharing a line
+            # with code nor a "//" inside a string literal can hide a reference.
+            function strip(l,   out, i, c, n, inStr, esc) {
+                out = ""; n = length(l); i = 1
+                while (i <= n) {
+                    c = substr(l, i, 1)
+                    if (inBlock) {                                  # inside /* … */
+                        if (substr(l, i, 2) == "*/") { inBlock = 0; i += 2 } else { i++ }
+                        continue
+                    }
+                    if (inStr) {
+                        out = out c
+                        if (esc) { esc = 0 }
+                        else if (c == "\\") { esc = 1 }
+                        else if (c == "\"") { inStr = 0 }
+                        i++
+                        continue
+                    }
+                    if (substr(l, i, 2) == "/*") { inBlock = 1; i += 2; continue }
+                    if (substr(l, i, 2) == "//") { break }          # rest of the line is a comment
+                    if (c == "\"") { inStr = 1 }
+                    out = out c
+                    i++
+                }
+                return out
+            }
             {
-                line = $0
-                sub(/\/\/.*/, "", line)                       # strip a trailing line comment
+                line = strip($0)
                 # The NAME itself is banned — that covers the plain import, an aliased import,
                 # a qualified call (even split across lines: the prefix stays on one line), and
                 # a reflective Class.forName("android.util.Log").
@@ -87,7 +125,7 @@ scan() {
             printf '%s\n' "$out"
             findings=$((findings + 1))
         fi
-    done < <(find "$src" \( -name '*.kt' -o -name '*.java' \) -type f | sort)
+    done < <(find "$src" \( -name '*.kt' -o -name '*.java' \) -type f -not -path '*/build/*' | sort)
 
     if [ "$findings" -eq 0 ]; then
         echo "CHECK-ANDROID-LOG-CONTAINMENT RESULT: OK (0 files)"
@@ -99,7 +137,7 @@ scan() {
 
 if [ "${1:-}" = "--scan" ]; then
     shift
-    scan "${1:?--scan needs a source dir}" "${2:-$DEFAULT_ALLOW}" "${3:-$DEFAULT_EXCLUDE}"
+    scan "${1:?--scan needs a source dir}" "${2:-$DEFAULT_ALLOW}"
     exit $?
 fi
 
@@ -113,9 +151,11 @@ echo "== check-android-log-containment =="
 
 FIX="$(mktemp -d -t log-containment.XXXXXX)"
 trap 'rm -rf "$FIX"' EXIT
-SRC="$FIX/src/main/kotlin/com/vreader/app"
-mkdir -p "$SRC/diagnostics" "$SRC/reader" "$FIX/src/main/java/com/vreader/app" \
-         "$FIX/src/test/kotlin" "$FIX/src/androidTest/kotlin" "$FIX/src/debug/kotlin"
+SRC="$FIX/app/src/main/kotlin/com/vreader/app"
+mkdir -p "$SRC/diagnostics" "$SRC/reader" "$FIX/app/src/main/java/com/vreader/app" \
+         "$FIX/app/src/test/kotlin" "$FIX/app/src/androidTest/kotlin" "$FIX/app/src/debug/kotlin" \
+         "$FIX/identity/src/main/kotlin" "$FIX/app/build/generated" \
+         "$FIX/app/src/main/kotlin/nested/src/test/kotlin"
 
 # 1. qualified form — must be flagged.
 cat > "$SRC/reader/Qualified.kt" <<'KOTLIN'
@@ -190,22 +230,67 @@ class Reflective { fun go() = Class.forName("android.util.Log") }
 KOTLIN
 
 # 10. a JAVA production file — the source set is shipped, so it must be scanned.
-cat > "$FIX/src/main/java/com/vreader/app/LegacyBridge.java" <<'JAVA'
+cat > "$FIX/app/src/main/java/com/vreader/app/LegacyBridge.java" <<'JAVA'
 package com.vreader.app;
 import android.util.Log;
 public class LegacyBridge { void go() { Log.w("Reader", "escaped"); } }
 JAVA
 
-# 11-13. NON-shipped source sets — must be skipped by the exclude rule.
+# 11-13. NON-shipped source sets — must be skipped, matched as the segment directly
+# beneath a module (so a misleadingly NESTED src/test path, fixture 17, is NOT skipped).
 for set in test androidTest debug; do
-    cat > "$FIX/src/$set/kotlin/Harness.kt" <<'KOTLIN'
+    cat > "$FIX/app/src/$set/kotlin/Harness.kt" <<'KOTLIN'
 package com.vreader.app
 import android.util.Log
 class Harness { fun go() = Log.w("t", "allowed here") }
 KOTLIN
 done
 
-OUT="$("$0" --scan "$FIX/src")"; RC=$?
+# 14. ANOTHER Gradle module — production Kotlin outside :app must still be scanned.
+cat > "$FIX/identity/src/main/kotlin/Contract.kt" <<'KOTLIN'
+package vreader.contracts
+import android.util.Log
+class Contract { fun go() = Log.w("t", "escaped via another module") }
+KOTLIN
+
+# 15-16. The two comment/string evasions round 2 produced against the line-regex version.
+cat > "$SRC/reader/InlineBlock.kt" <<'KOTLIN'
+package com.vreader.app.reader
+class InlineBlock {
+    /** doc */ val priority = android.util.Log.WARN
+}
+KOTLIN
+
+cat > "$SRC/reader/SlashInString.kt" <<'KOTLIN'
+package com.vreader.app.reader
+class SlashInString {
+    val priority = "https://example".length + android.util.Log.WARN
+}
+KOTLIN
+
+# 17. a nested, misleading "src/test" path INSIDE a production source set — must be scanned.
+cat > "$FIX/app/src/main/kotlin/nested/src/test/kotlin/Sneaky.kt" <<'KOTLIN'
+package com.vreader.app
+class Sneaky { fun go() = android.util.Log.w("t", "hidden under a fake test path") }
+KOTLIN
+
+# 18. generated build output — never scanned.
+cat > "$FIX/app/build/generated/Generated.kt" <<'KOTLIN'
+package com.vreader.app
+import android.util.Log
+class Generated { fun go() = Log.w("t", "generated") }
+KOTLIN
+
+# 19. a MULTI-LINE block comment whose body has no leading '*' — prose, must NOT be flagged.
+cat > "$SRC/reader/LooseBlockProse.kt" <<'KOTLIN'
+package com.vreader.app.reader
+/*
+  historical note: this class used to call android.util.Log directly.
+*/
+class LooseBlockProse { fun fine() = Unit }
+KOTLIN
+
+OUT="$("$0" --scan "$FIX")"; RC=$?
 
 # Assertions are anchored on the "<file>:<line>:" FINDING form, never a bare filename —
 # the RESULT summary line itself names VLog.kt, which a loose grep happily matches.
@@ -231,8 +316,8 @@ grep -q "OtherLog\.kt:[0-9]" <<<"$OUT" \
     && fail "a non-android Log type was flagged" \
     || ok "short form without the android import ignored"
 
-# The four evasions the audit named, plus the Java source set.
-for evasion in Aliased Wildcard SplitCall Reflective; do
+# Every evasion the two audit rounds named.
+for evasion in Aliased Wildcard SplitCall Reflective InlineBlock SlashInString Sneaky; do
     grep -q "$evasion\.kt:[0-9]" <<<"$OUT" \
         && ok "evasion caught: $evasion" \
         || fail "EVASION NOT CAUGHT: $evasion"
@@ -241,9 +326,21 @@ grep -q "LegacyBridge\.java:[0-9]" <<<"$OUT" \
     && ok "shipped .java source is scanned" \
     || fail "a Java production file evaded the gate"
 
+grep -q "Contract\.kt:[0-9]" <<<"$OUT" \
+    && ok "another Gradle module's production source is scanned" \
+    || fail "production Kotlin outside :app evaded the gate"
+
 grep -q "Harness\.kt:[0-9]" <<<"$OUT" \
     && fail "a non-shipped source set (test/androidTest/debug) was flagged" \
     || ok "test / androidTest / debug source sets excluded"
+
+grep -q "Generated\.kt:[0-9]" <<<"$OUT" \
+    && fail "generated build/ output was flagged" \
+    || ok "generated build/ output excluded"
+
+grep -q "LooseBlockProse\.kt:[0-9]" <<<"$OUT" \
+    && fail "a multi-line block comment without leading '*' was flagged (false positive)" \
+    || ok "multi-line block-comment prose ignored"
 
 [ "$RC" -eq 1 ] \
     && ok "exit 1 on findings" \


### PR DESCRIPTION
## Summary

`VLog` (the logging facade), `RingBufferDiagnosticsSource`, `CompositeDiagnosticsSource`, the category model — and migration of all **6** existing `android.util.Log` call sites.

Plus a real enforcement gate: `scripts/__tests__/check-android-log-containment.sh`.

Part of feature #2023 (#164). Foundational WI.

## Three things designed against passing-while-wrong

**Dedupe keys on the VLog sequence id, not on text.** A `VLog` event lands in *both* sources — the ring directly, and logcat via the forwarded call. Deduping by `(time, category, message)` would collapse two genuinely distinct entries sharing text and timestamp. Both directions are asserted, and the mutation confirms it: switching to a text key reddens `twoDistinctEntriesWithByteIdenticalTextAndTimestampBothSurvive`; disabling dedupe entirely reddens `anEventPresentInBothSourcesAppearsExactlyOnce`.

**Forwarding is asserted on the LOG, not the ring.** Observing the ring sink proves only that the ring recorded it — §10's backward-compat guarantee rests on the `android.util.Log` forward actually happening. Robolectric 4.13 is already a `testImplementation` dep, so `VLogTest` asserts against the **real** call via `ShadowLog`.

An injectable seam was **rejected**, with the right reasoning: it would only prove `VLog` called its own indirection — re-opening the exact hole the rule closes, one layer down.

Mutation proof of independence: removing the forward reddens **8 forwarding tests while all 15 ring tests and every ring-side `VLogTest` case stay green.**

**The containment rule is a gate, not a bullet.** "No production source outside `VLog.kt` references `android.util.Log`" is inert as an acceptance bullet — nothing runs it. The script matches the qualified form **and** the short `Log.w(` form with an import, which matters because **4 of the 6 existing sites used the short form**; a qualified-only check would have reported green while missing most of them.

23 self-test assertions including **9 evasion fixtures** (qualified, short+import, aliased import, wildcard import, split call, reflective string, Java source, nested fake `src/test` path, raw string, char literal) and 3 false-positive fixtures. Against the real tree: `CHECK-ANDROID-LOG-CONTAINMENT RESULT: OK (0 files)`.

## What the 6 call sites revealed

`FoliateBridge` and `BookShareIntent` log from an **anonymous `WebChromeClient`** and from **top-level functions**, so a stack-walk-derived class name would have produced `FoliateBridge$attach$2` and `BookShareIntentKt` — and R8 renaming would compound it. That is why `VLog` takes an explicit `origin: String` rather than the plan's §4.1 signature; each site already held the right string in its `TAG` constant.

Also checked before committing to an unconditional forward: both JVM tests that exercise migrated files are already Robolectric, so the forward cannot trip "not mocked".

## Deliberate breaking change, pinned by test

`VLog` emits with tag = `DiagnosticsCategory.tag` (`"Reader"`), **not** the old per-class tag, and prefixes the class into the body (`"[FoliateBridge] …"`). Both halves asserted, so the break is tested rather than discovered.

## Gate 4 — 4 rounds, `follow-up-recommended`

Rounds 1–3 in the artifact. **Round 3's fixes were real concurrency and lexer code**, so rather than accept the escalation by argument, the orchestrator ran a confirming round — the same standard as WI-1, where that found a third `CancellationException` site the lane had missed.

**Round 4: `VERDICT: clean`, zero findings.** The atomic `Installation` snapshot is taken once and used consistently with no state read escaping it on any path including the uninstalled one; racing `install()` calls are **whole-object last-writer-wins, not torn**. The raw-string lexer holds across nested quotes, `//` and `/*` inside raw strings, the literal text `Log.w(` inside a raw string, an unterminated raw string at EOF, char literals, and escaped quotes. No rounds-1–2 regression.

Worth noting the lane's judgement on one round-3 item: it **declined to re-adopt the phased-milestone concurrency remedy**, because the same auditor had rejected that approach in round 2 and re-adopting it would oscillate between two reviewers' preferences. It validated empirically instead — **4/4 failures without `synchronized`, 5/5 passes with**, in 33 ms.

## Accepted residuals — recorded in the code, not closed

1. **Sequence ids repeat across launches with p ≈ 1/2²¹** (21-bit launch nonce). Eliminating it needs durable on-disk state, putting an I/O dependency and a failure mode inside a logging facade. Loss on a repeat is bounded — a handful of prior-launch logcat entries deduped away — and it is **strictly better than the pre-fix behaviour, where that happened on every launch**. Recorded in `VLog.kt`'s KDoc.
2. **A runtime-assembled class name** (`Class.forName("android." + "util.Log")`) is invisible to any textual gate. The gate stops accidental drift and honest reintroduction; it is not an adversarial sandbox. Recorded in the script header.
3. **`VLogTest.kt` is 392 lines and hosts `DiagnosticsCategoryBoundingTest`** — WI-3's write-set allots exactly three test files while owning `DiagnosticsCategoryBounding.kt`, whose acceptance bullet sits in WI-4 (which cannot write that file). A one-line follow-up under a wider write-set.

## Rule 51 flagged forward

`DiagnosticsCategoryBounding`'s `COLLAPSED_BUCKET` label (`"Other"`) is **not** in the design bundle — `DIAG_CATEGORIES` is `All` plus the six category tags. It is isolated in one named constant for **WI-6a to adjudicate** rather than quietly shipped as invented UI text.

## Validation

- **203 tests / 0 failures** re-run by the orchestrator across the WI-3 suites, WI-1/WI-2's, and the JVM suites of every migrated file. Counts from the JUnit XML.
- Containment gate re-run: `ALL PASS`.
- Version bumped: `android/v0.20.26` → `android/v0.20.27`.

## Type of Change

- [x] Feature WI (part of feature #2023)
