### PR TITLE
rules(47): Gate-2 plan audits must commit an enumerated artifact

### DIFF
--- a/.claude/codex-audits/plan-feature-141-gate2-audit.md
+++ b/.claude/codex-audits/plan-feature-141-gate2-audit.md
@@ -1,0 +1,86 @@
+---
+gate: 2
+kind: plan-audit
+feature: 141
+plan: dev-docs/plans/20260806-feature-141-android-filterable-toc.md
+rounds: 2
+final_verdict: pending-round-2
+---
+
+# Gate-2 plan audit — feature #141 (Android filterable TOC)
+
+Rule 47 Gate 2 requires an independent audit. This artifact exists because feature #152's
+round 1 found that a *previous* Gate-2 audit's findings were unrecoverable — the plan said
+"6 High + 8 Medium + 2 Low remain open" and the list existed nowhere in the repo, so no one
+could tell whether a later draft had addressed them or silently dropped them. Gate 4 already
+commits its audit log; Gate 2 now does too.
+
+## Method — two independent auditors, deliberately different
+
+- **Static**: Codex `gpt-5.5`, effort `high`, read-only, via `scripts/run-codex.sh` (rule 53).
+- **Empirical**: a separate agent that implemented the plan's §5.1 algorithm in Java, ran ~90
+  hostile inputs on JDK 17, **and ran the real iOS `TOCTitleFilter.swift` against the same
+  inputs**, plus a desktop benchmark over 1 859 realistic CJK titles.
+
+The split earned its cost: they **disagreed**, and the disagreement was the most useful output
+(see "Disproven by measurement").
+
+## Round 1 — `block-recommended`
+
+| # | Sev | Finding | Disposition in v2 |
+|---|---|---|---|
+| 1 | High | Match ranges computed on the collapsed title, rendered from the raw one. Measured: `range [0..6]` selects `"Chapter"` on display, `"   Chap"` on raw. Not limited to line-break titles — `collapseLineBreaks` trims *every* title. Mirror case is an `AnnotatedString` bounds **crash**. | Fixed structurally: `TocTitleFilter.displayTitle(entry)` is the sole producer, owns the `"Untitled"` fallback; `TocContentsRow` takes `title: String` **required**; `boldedSnippet` clamping so the mirror case degrades to a wrong tint, not a crash. |
+| 2 | High | The "copied verbatim from iOS" folding contract is **false on 3 of the 4 exclusions it names** — measured against real iOS: `ﬁ`→`fi` MATCH, `Straße`→`strasse` MATCH, `ΟΔΟΣ`→`οδός` MATCH, all no-match on the plan's algorithm; Arabic hamza **over**-matches. Full-width exclusion is the one true claim. | Claim retracted in §3, measured table inserted. Algorithm → per-code-point ICU `UCharacter.foldCase(String, FOLD_CASE_DEFAULT)`, closing ß + final sigma with the index map intact. Residuals pinned as named tests; added `caseFold_usesFullFoldingNotSimple` because the `foldCase(int, boolean)` overload does *simple* folding. |
+| 3 | Med | Perf budget aimed at the wrong risk. Desktop: keystroke **0.035 ms** warm vs an 8 ms budget (~200×); one-time fold **18.66 ms** vs 50 ms (~2.7×) — and `lazy(NONE)` defers it *into* the first keystroke. `displayTitles` eager map (2.94 ms × every sheet open) unbudgeted. | Three separate budgets (A visible rows / B corpus fold ≤120 ms / C keystroke ≤8 ms); eager map deleted; explicit note that **a debounce delays the fold, it does not reduce it**; off-thread fallback pre-designed; cost test moved WI-6 → WI-1. |
+| 4 | Med | `foldedQuery.isEmpty()` diverges from iOS, which gates on the **trimmed** query. Measured: a lone combining acute → iOS "No chapters match", plan → full unfiltered list. | Gating moved to `trimmedQuery`. |
+| 5 | Med | `IntRange` inclusivity never stated; `originalRange(foldedStart, foldedEndExclusive): IntRange` mixes conventions; tests assert range **count**, not bounds. | Convention stated (inclusive, matching #133); signature → `originalRange(foldedFirst, foldedLast)`; a test asserts hand-computed exact `(first, last)`. |
+| 6 | Med | Stale model fact: `ReaderTheme` called a 4-case enum; it has **five** (`Paper, Sepia, Dark, Oled, Photo`). Orchestrator-confirmed at `ReaderTheme.kt:14-26`. | Corrected; tests iterate `ReaderTheme.entries`. |
+| 7 | Med | Scroll-on-filter keyed only empty/non-empty → refining `Chapter` → `Chapter 1999` leaves a one-row result at a stale offset. | Keyed on `trimmedQuery` + a `wasFiltering` flag; connected test added. |
+| 8 | Low | False "(verified)" claim that Kotlin `trim()` does not strip NBSP. It does — `Char.isWhitespace()` is `isWhitespace \|\| isSpaceChar`, proven by disassembling the shipped stdlib. | Rationale corrected, redundant predicate dropped, the Java-`trim()` trap kept and pinned. |
+| 9 | Low | Two folding paths (`filtered` consumes pre-folded; `matchRanges` re-folds per row) that must never disagree. | `matchRanges(folded: FoldedTitle, …)` — exactly one fold per title. |
+| 10 | Low | Two overstated citations: the design's "~2k entries" ceiling presented as corroboration (real corpus 1 859; existing connected test already runs 2 000), and "Design gaps — nothing is missing" (the design's no-TOC state has copy + an "Open Search" CTA; Android renders plain "No contents"). | Both softened; §2.2 → "no #141-blocking gap", `NoTocEmpty` fidelity gap recorded and routed to the orchestrator. |
+
+### Disproven by measurement — recorded so it is not re-raised
+
+The **static** auditor claimed the folded→original index map would mis-highlight Hangul, emoji
+modifiers/ZWJ, and combining marks. The **empirical** auditor implemented the scheme and measured
+exactly those cases across ~90 inputs with **zero wrong ranges** — `İ` at position 0 and mid-title,
+Hangul NFD expansion before/after/inside a match, jamo vs precomposed both directions, decomposed
+`e`+U+0301 with the match ending on and spanning the mark, stacked marks, surrogate pairs
+before/inside/as-query, Arabic harakat, Hebrew niqqud, orphan combining marks, partial-expansion
+jamo queries, CJK substrings with no word boundaries, `"aa"` in `"aaaa"` → exactly 2 ranges.
+
+The `starts`/`ends` scheme including "extend `ends` over immediately-following stripped marks" is
+sound. **Not actioned**, by decision. Re-raising it requires a concrete input and the exact wrong
+indices it produces.
+
+### Rejected remedy
+
+The static auditor recommended reusing `SearchTextNormalizer` (NFKC → ICU `foldCase` → diacritic
+strip). **Not a drop-in**: it is length-changing (destroys the index map the measurement just
+validated), recomposes to NFC, CJK-segments, and NFKC-folds full-width — which iOS's TOC filter
+does **not**. Cited in the plan with those three reasons.
+
+### Verified TRUE in round 1 — all seven wiring claims
+
+Production surface is `TocBookmarksSheet`; `TocContentsSheet(...)`'s only caller is
+`androidTest/.../TocContentsSheetTest.kt:185`; the four production call sites are exact;
+ordinal-from-position, highlight-from-position, the `LazyListState` key, and render-time line-break
+collapsing all confirmed; iOS #94's `visibleEntries` is a plain computed property with **no**
+debounce anywhere in the file. Largest real TOC corroborated at **1 859** (`黑暗血时代.txt`);
+`道诡异仙` counts 1 042 navPoints; #138's ~30 695 is a **page** count and was correctly not used.
+
+### Author-found defect during revision
+
+Not from either auditor: `filtered(...)` took `foldedCorpus.value`, which would have forced the
+lazy fold on **every sheet open** — reinstating the cost-A regression one line below its deletion.
+Now takes `Lazy<List<FoldedTitle>>` and returns from the blank-query branch before touching
+`.value`, with `blankQuery_neverForcesTheFold` asserting `isInitialized() == false`.
+
+## Round 2 — in progress
+
+Prompt: verify each round-1 finding resolved; evaluate the ICU switch (does `android.icu` exist at
+this minSdk, does Robolectric provide it, does per-code-point full folding preserve the index map
+when a fold expands); confirm the `Lazy` change has no other force site; confirm every
+`TocContentsRow` call site is updated and that moving the `"Untitled"` fallback breaks no consumer.
+Result appended on completion.

--- a/.claude/codex-audits/plan-feature-142-gate2-audit.md
+++ b/.claude/codex-audits/plan-feature-142-gate2-audit.md
@@ -1,0 +1,59 @@
+---
+gate: 2
+kind: plan-audit
+feature: 142
+plan: dev-docs/plans/20260806-feature-142-android-azw3-annotations.md
+rounds: 2
+final_verdict: pending-round-3
+---
+
+# Gate-2 plan audit — feature #142 (Android AZW3 selection + highlights/notes)
+
+Auditor: Codex `gpt-5.5`, effort `high`, read-only, via `scripts/run-codex.sh` (rule 53).
+Committed per the Gate-2 artifact requirement (rule 47) — see
+`.claude/codex-audits/plan-feature-141-gate2-audit.md` for why that requirement exists.
+
+## Auditor reliability note (round 1)
+
+Round 1 cited paths under `android/app/src/main/kotlin/me/lllyys/vreader/…`. **There is no `me/`
+package in this repo** — the real root is `com/vreader/app/…` — and design citations dropped the
+`vreader-fidelity-v1/project/` segment. Every finding was therefore re-verified at real paths
+before being actioned; **none turned out to rest on a nonexistent file**, so nothing was dismissed
+on the citation error. Round 2's prompt required path verification and its citations check out.
+
+## Round 1 — `block-recommended` (4 High, 3 Medium, 2 Low)
+
+| # | Sev | Finding | Round-2 status |
+|---|---|---|---|
+| 1 | High | Payload caps applied too late — `FoliateBridge.kt:137` hands `message.data` straight to `FoliateMessageParser.parse`, which calls `parseToJsonElement` immediately (orchestrator-confirmed at the real path), so field-level caps never see the hostile input first. | **PARTIALLY** — cap added in the right place; the author's narrowing (`WebMessageCompat.data` is already a String, so the cap bounds JSON amplification, not receipt) is confirmed correct. But the **sizing is wrong**: see H1. |
+| 2 | High | Connected tests allowed to `Assume`-skip — bug #369's exact shape, where a skip exits 0 like a pass. | **RESOLVED** — WI-7 acceptance uses the fail-hard `importRealBook()` pattern (`assertTrue` + content-digest identity); slice tier keeps skip helpers explicitly; Gate-5 evidence requires non-zero executed count and zero skips. |
+| 3 | High | Standalone-note acceptance had no entry point to create one. | **RESOLVED by removal** — `AnnotationsRepository.addNote` has **zero** production call sites; EPUB/TXT "Note" attaches to a highlight (`ReaderActivity.kt:678`, `TxtReaderActivity.kt:1171`). Dropped from scope; no control invented. Orchestrator filed the app-wide gap as **feature #176**. |
+| 4 | High | Tapped-highlight routing conflicts with the newer committed design (`highlight-popover-canvas-artboards.jsx:666`: *"Trigger: single tap on an existing highlight… Long-press route stays on the selection popover"*). | **ADJUDICATED, not fixed** — the conflict is real but **pre-existing and app-wide**: `ReaderActivity.kt:598` and `TxtReaderActivity.kt:1107` already route taps into `PopoverMode.EDIT`. #142 stays consistent with every other format; cross-format adoption tracked as **feature #175**. |
+| 5 | Med | The bundle's posted selection `rect` is section-iframe-relative (the tap path routes through `mapTapToHostViewport` for exactly that reason), and a `frameLeft`-only probe ignores frame top, RTL, writing mode, scrolled-vs-paginated, and multi-rect selections. The auditor's fix would require touching the SHA-pinned bundle. | **PARTIALLY** — premise **verified**: `Azw3DomProbe.kt:58/:156` already evaluates JS in the shell and reaches `renderer.getContents()[0].doc` with `Range.getClientRects()`; `foliate-bundle.js:7141` reads `frameElement.getBoundingClientRect()` from the same context; `reader.html:5` pins `initial-scale=1`. **No bundle change needed** — SHA pin and rule-54 posture untouched. Remaining defects: M1. |
+| 6 | Med | Coroutine scopes unpinned — the shape of the Activity leak #165 WI-7 fixed one week earlier. | **RESOLVED** — per-work-kind scope table: `appScope` for repository writes capturing only value types, composition/lifecycle for reads, WebView calls and the probe; callbacks nulled + `teardown()` in the existing `onDispose`. Caution carried to the WI brief: existing EPUB code still captures Activity fields inside `appScope`; do not copy it. |
+| 7 | Med | Write-set collision with the in-flight bug #368 lane (`Azw3ReaderActivity.kt` / `Azw3ReaderChrome.kt`). | **RESOLVED** — WI-1…WI-4 independent, WI-5/WI-6 wait for #368, WI-7 test/evidence-only. Verified against the WI file lists. |
+| 8/9 | Low | Bundle/API assumptions verified; anchor/restore trap **independently confirmed on both platforms** (Android `anchor = null` on restore, iOS `anchor: nil`, `contracts/identity/backup-format.md` states `locatorJSON` is plain `Locator` JSON). | **RESOLVED** — provenance test extended to pin `selection`/`annotation-show`/`create-overlay` and `addAnnotation`/`deleteAnnotation`/`deselect`, so bundle drift fails visibly. |
+
+### The plan's own highest-value catch, confirmed by the auditor
+
+The backup wire carries **no anchor**, so `restoreAnnotations` inserts `anchor = null`. Reading the
+CFI only from the anchor — the obvious iOS-parity design — would make **every restored AZW3
+highlight permanently invisible**. The `record.anchor?.cfi ?: record.locator.cfi` fallback and its
+RED test stay.
+
+## Round 2 — `block-recommended` (2 new)
+
+- **H1 (High)** — `MAX_RAW_MESSAGE_CHARS = 4 Mi` is **below** the worst-case *legitimate*
+  `book-ready`. Each TOC row serialises as `{label, href, subitems}`; a 10 000-entry flat TOC is
+  ~370 112 chars with empty strings but **~4 370 112** with 200-char labels and hrefs, above the
+  4 194 304 cap — so the cap can drop a legitimate message and strand the reader before `Loaded`.
+  **One of the two proposed fixes is closed**: `FoliateTocParser.kt:99-100` preserves labels and
+  hrefs *byte-for-byte* by design, because `relocate.tocHref` matching is byte-exact — capping them
+  would break #140's current-chapter highlighting. So the cap must be raised (derived, not picked)
+  or made per-message-name.
+- **M1 (Medium)** — the anchor probe overclaims the focus edge and accepts degenerate rects: it
+  always takes `rects[rects.length - 1]`, but the Selection API defines **backward** selections
+  where focus is the range *start*; and it accepts any non-empty rect list, where the existing probe
+  filters by width (`Azw3DomProbe.kt:91`). Vertical writing mode is claimed but untested.
+
+Round 3 (the rule-47 cap) is in progress on both.

--- a/.claude/codex-audits/plan-feature-152-gate2-audit.md
+++ b/.claude/codex-audits/plan-feature-152-gate2-audit.md
@@ -1,0 +1,86 @@
+---
+gate: 2
+kind: plan-audit
+feature: 152
+plan: dev-docs/plans/20260806-feature-152-android-cover-extraction.md
+rounds: 2
+final_verdict: pending-round-2
+---
+
+# Gate-2 plan audit — feature #152 (Android embedded cover extraction + display)
+
+## Why this file exists
+
+Round 1 found that the **previous** Gate-2 audit of this feature left no artifact. The superseded
+v2 plan records *"6 High + 8 Medium + 2 Low remain open"* and **that list exists nowhere in the
+repo**. A v3 was written from the code instead, and no one could show whether those 16 findings
+were addressed or silently dropped — the author searched and confirmed the artifact is simply
+absent. Gate 4 has always committed its audit log; Gate 2 now does too, and this is the
+demonstration of why.
+
+## Method — two independent auditors
+
+- **Static**: Codex `gpt-5.5`, effort `high`, read-only, via `scripts/run-codex.sh` (rule 53).
+- **Empirical**: a separate agent that ported the plan's §4 MOBI spec to Kotlin/Java, ran it
+  against **4 real books and 39 mutated files**, cross-checked every extraction against an
+  independently written Python MOBI reader, and disassembled the resolved Readium AAR.
+
+## Round 1 — `block-recommended`. All 15 findings accepted; 3 remedies deviated.
+
+### Found only by execution
+
+| # | Sev | Finding | Fix in v4 |
+|---|---|---|---|
+| C-1 | **Critical** | The §4 restatement **dropped Swift's `end <= data.count` guard**. Record-table entry 136 set to `0x7FFFFFF0` → computed length **2 147 138 052 bytes**; `OutOfMemoryError` at every heap size from `-Xmx64m` to `-Xmx1g`, where the iOS-faithful path returns `None`. Critical because **`OutOfMemoryError` is an `Error`, not an `Exception`** — the plan's `catch (Exception)` contract misses it, so it escapes the coroutine and kills the app-scope backfill for the whole library. | Three pre-allocation guards (`start > fileLength`, `end > fileLength` — which subsumes non-monotonic offsets — and a 64 MiB `MAX_RECORD_BYTES`); `CoverCoordinator` catches `Throwable` as defence in depth **with an explicit note that catching OOM after the fact is not the fix**; 3 new cases, one asserting no OOM escapes at `-Xmx64m`. |
+| H-2 | High | The `Failed`/`None` split **contradicts the plan's own §7 table**: moving from mapped `Data` to `RandomAccessFile` turns bounds violations into `EOFException` (an `IOException`), so cases ①③⑨ that expect `None` measurably return `Failed` — meaning every truncated book is re-parsed on **every app start, forever**, the exact cost the memoisation exists to prevent. 6 of 39 mutations diverge this way. | Normative content-vs-access table: `None` = reachable and structurally parsed (incl. EOF during a bounded read); `Failed` = could not be accessed (missing file, permission, device I/O). Boundary pinned at the *open*. New contract test; §7 expectations corrected. |
+| H-3 | Med→High | `CoverStore.save()` recycling a caller-owned bitmap is unsound — **bytecode-proven**: `BitmapKt.scaleToFit` returns `this` unchanged when the source fits (`34: aload_0 / 35: areturn`), and `InMemoryCoverService` holds the bitmap in a `private final` field, so `coverFitting` can return the `Publication`'s retained bitmap. A double-`save` also hands a recycled bitmap to `compress()`. **Risk-4's stated mitigation was a grep — which passes while the defect is present.** | Reversed: `CoverStore` **borrows**, no `.recycle()` anywhere. Risk 4 rewritten to name the old mitigation as itself defective; replaced by a behavioural double-save test. |
+
+### Static findings
+
+| # | Sev | Finding | Fix in v4 |
+|---|---|---|---|
+| H-4 | High | The rule-51 gap is larger than the plan's G1. | **Deviation** — verified the pencil in `vreader-book-details.jsx:128-140` sits *outside* the `missingCover` ternary (renders in both branches) and `vreader-generated-cover.jsx:31-34` says swap controls *return* when a cover store lands. Filed as G2. Remedy: **move WI-8 to #153** rather than commission new design. |
+| H-5 | High | Extraction can still race a user-chosen cover. | `saveIfAbsent` (non-replacing) vs `saveReplacing` (#153 only), both under a per-key `Mutex` held across re-check → temp write → `renameTo`; latched interleaving test ×50. |
+| H-6 | High | v2 reconciliation not independently auditable. | Confirmed **no v2 artifact exists anywhere**; §12.1 states what is reconcilable and that the unenumerated residue **cannot be shown to have been addressed**. Produced this artifact requirement. |
+| M-9 | Med | `StorageNaming` maps every non-`[A-Za-z0-9._-]` char to `_`, so `a:b` and `a/b` collide, contradicting the plan's own non-collision test. | **Deviation** — neither proposed fix taken: `fileNameForKey` already names every book file on every device, so changing the mapping orphans existing libraries; and the substitution is injective on `Identity.canonicalKey`'s real domain. Mapping frozen, precondition explicit, contradictory tests deleted, injectivity property test added. |
+| M-10 | Med | No cover deletion / orphan cleanup. | `onBookDeleted` + a `sweepOrphans()` backstop at `start()`, both idempotent and non-throwing. |
+| M-11 | Med | "Import-time extraction" under-specified — `RestoreImporter` calls `BookImporter` directly. | Four `importStream` callers verified; hook moved to the convergence point (`BookImporter.onImported`, fire-and-forget on the app scope). |
+| M-12 | Med | WI parallelisation collides — 5 WIs write under `library/covers/`. | Exact per-WI **file** lists, no shared files; parallelism claim **downgraded honestly** (both extractors depend on WI-3 and share one emulator, so no speed-up claimed). |
+
+### Empirical mediums / lows
+
+| # | Sev | Finding | Fix in v4 |
+|---|---|---|---|
+| M-7 | Med | Risk-1's Gate-5 mitigation **cannot test what it is assigned to** — all three fixtures are single-part `mobiType = 2` files despite `.azw3`; zero `BOUNDARY` markers across 153 records. | **Deviation** — the false claim is withdrawn; the MOBI6+KF8 limitation ships **untested and named**, with a Residuals section required in the evidence file. |
+| M-8 | Med | `firstImageIndex == 0xFFFFFFFF` occurs in a real committed fixture (`DebugFixtures/divider-azw3.azw3`) and was documented only for EXTH 201/202. | Reconfirmed by parsing the file; sentinel checked before the EXTH scan; §7 case added. |
+| L-13 | Low | Fixture policy over-pessimistic — `androidTest/assets/foliate-spike/book.azw3` is **byte-identical** to the "gitignored" real book (`md5 f4ae9259b82cc2a765242bebd015df84`, 6 288 371 B), so that suite is CI-safe. | Adopted; digest pinned; fail-hard presence assertions, never `assumeTrue` (bug #369). |
+| L-14 | Low | §7 omitted the one mode that actually crashes. | Five cases added. |
+| L-15 | Low | `Signature:` attribute quoted as `descriptor:`. | Corrected. |
+
+### What the measurement CONFIRMED (recorded, not buried)
+
+Ported faithfully with the plan's two stated Kotlin corrections, the spec extracted the **correct**
+cover from 3/3 cover-bearing real books — the 6.3 MB CJK book → record 135, 379 691 B JPEG, 542×800,
+rendered and visually confirmed as the real jacket — correctly returned `None` for the one book with
+none, **matched an independent Python reader byte-for-byte** (`md5 fa84a175…`), returned cleanly on
+36 of 39 hostile inputs with no hang, and parsed a 300 MB sparse file at `-Xmx16m` with **0 MB heap
+delta**.
+
+Both claimed Kotlin corrections are real, reproduced in compiled Kotlin: `0xFFFFFFFF` is typed
+`Long`, so an `Int` read gives `-1` → `rec[134]`, a **non-image record** (silently wrong bytes, not
+an error); and `numRecords` at file offset 76 is `00 99`, so an unmasked read gives **-103** — an
+unmasked port fails on the *first field it reads*, on a real book. `firstImageIndex` is an
+**absolute** PDB record index and EXTH-201/202 are **relative** to it — proven by mutation, since
+the happy path cannot discriminate (`135 + 0 == 135`).
+
+Readium independently verified from the resolved AAR: `coverFitting(Publication, Size,
+Continuation) -> Bitmap?`, no `@ExperimentalReadiumApi` — a sound negative, proven by finding 31
+other classes in the same jar that **do** carry it.
+
+## Round 2 — in progress
+
+Verifying each fix; evaluating the three deviations (WI-8 → #153, frozen sanitiser, KF8 untested);
+and sweeping for defects the revision introduced — the 64 MiB cap vs a legitimately large cover,
+`catch (Throwable)` vs `CancellationException`, the fire-and-forget `onImported` hook vs
+transaction visibility on a 200-book restore, per-key `Mutex` growth, and `sweepOrphans` racing a
+mid-import book. Result appended on completion.

--- a/.claude/rules/47-feature-workflow.md
+++ b/.claude/rules/47-feature-workflow.md
@@ -43,6 +43,12 @@ Audit prompt must explicitly request:
 
 Track audit rounds in the plan's revision history. The author rewrites the plan to address findings; the auditor re-reviews. Same loop until clean.
 
+**Commit the audit artifact (binding).** Gate 2 writes `.claude/codex-audits/plan-feature-<N>-gate2-audit.md`, committed on the branch that carries the plan, in the same shape Gate 4 already requires: frontmatter (`gate: 2`, `kind: plan-audit`, `feature`, `plan`, `rounds`, `final_verdict`) plus, for **every** round, an enumerated finding list — severity, the finding itself, and its disposition. "6 High + 8 Medium + 2 Low remain open" is not an enumeration.
+
+Record three things the round tables alone will not carry: (a) findings **rejected with reasoning** — a remedy declined on evidence is a decision, not an omission; (b) findings **disproven by measurement**, so a later round does not re-raise what was already tested; (c) what the audit **confirmed**, so a subsequent author knows which claims are load-bearing and already checked.
+
+**Why this is binding.** Feature #152's v2 plan stalled at Gate-2 round 2 recording exactly that unenumerated count, and the list existed **nowhere in the repo**. A v3 was written from the code instead, and no one could tell whether those 16 findings were addressed or silently dropped — the round-1 auditor of v3 raised it as a High for precisely that reason, and the author searched and confirmed the artifact was simply absent. A gate whose findings cannot be re-read is a gate that cannot be re-entered: the next draft starts blind, and the cost of every earlier round is lost. Gate 4's artifact requirement exists for the same reason; Gate 2 was the hole.
+
 **Why this gate exists**: Codex audits routinely catch 5-10 real bugs per round on non-trivial plans (compile-breaking model assumptions, missing preconditions, protocol shape mistakes). Skipping the audit shifts that cost into wasted implementation work.
 
 ## Gate 3 — TDD Implementation


### PR DESCRIPTION
**The failure this closes, from this session.** Feature #152's superseded v2 plan records *"6 High + 8 Medium + 2 Low remain open"* — and **that list exists nowhere in the repo**. A v3 was written from the code instead. Nobody could tell whether those 16 findings were addressed or silently dropped; the round-1 auditor of v3 raised it as a **High** for exactly that reason, and the plan author then searched and confirmed the artifact is simply absent.

Gate 4 has always committed its audit log. **Gate 2 was the hole.** A gate whose findings cannot be re-read is a gate that cannot be re-entered — the next draft starts blind, and the cost of every earlier round is lost.

## What the rule now requires

`.claude/codex-audits/plan-feature-<N>-gate2-audit.md`, committed on the branch carrying the plan, in the shape Gate 4 already uses: frontmatter plus, **for every round**, an enumerated finding list — severity, finding, disposition. *"6 High + 8 Medium + 2 Low"* is not an enumeration.

Plus three things a round table alone would not carry:

- **Rejected with reasoning** — a remedy declined on evidence is a decision, not an omission.
- **Disproven by measurement** — so a later round does not re-raise what was already tested.
- **Confirmed** — so a later author knows which claims are load-bearing and already checked.

## Ships with three real artifacts

The in-flight audits for **#141**, **#142**, and **#152**, each enumerated per round. They demonstrate all three of the extra sections rather than just asserting them:

- **Disproven** — #141's static auditor claimed the index map would mis-highlight Hangul, emoji and combining marks; the empirical auditor implemented the scheme and measured those exact cases across ~90 inputs with **zero** wrong ranges. Recorded as not-actioned, with the bar for re-raising it.
- **Rejected** — #152 declines three proposed remedies on evidence (changing the filename sanitiser would orphan every existing library; a KF8 fixture does not exist in the corpus; WI-8 moves to #153 rather than widening a design ask).
- **Confirmed** — #152's parser spec pulled the correct cover from 3/3 real books, byte-identical to an independent Python reader, with 0 MB heap delta at `-Xmx16m`.

Also recorded: #142's round 1 cited a package root (`me/lllyys/…`) that **does not exist** in this repo. Every finding was re-verified at real paths before being actioned — none rested on a nonexistent file — and the artifact says so, because an auditor's reliability is itself something the next round needs to know.

Meta-process change; no code paths touched, so no version bump.

## Type of Change
- [x] Rules / process